### PR TITLE
handle CMAKE_SYSTEM_NAME as conan -s os=System

### DIFF
--- a/conan.cmake
+++ b/conan.cmake
@@ -26,11 +26,15 @@ function(conan_cmake_settings result)
   endif()
 
   #handle -s os setting
-  set(CONAN_SUPPORTED_PLATFORMS Windows Linux Macos Android iOS FreeBSD)
-  if( CMAKE_SYSTEM_NAME IN_LIST CONAN_SUPPORTED_PLATFORMS )
-    set(_SETTINGS ${_SETTINGS} -s os=${CMAKE_SYSTEM_NAME})
-  else()
-    message(FATAL_ERROR "cmake system ${CMAKE_SYSTEM_NAME} is not supported by conan. Use one of ${CONAN_SUPPORTED_PLATFORMS}")
+  if(CMAKE_SYSTEM_NAME)
+  #use default conan os setting if CMAKE_SYSTEM_NAME is not defined
+    set(CONAN_SUPPORTED_PLATFORMS Windows Linux Macos Android iOS FreeBSD)
+    if( CMAKE_SYSTEM_NAME IN_LIST CONAN_SUPPORTED_PLATFORMS )
+    #check if the cmake system is a conan supported one
+      set(_SETTINGS ${_SETTINGS} -s os=${CMAKE_SYSTEM_NAME})
+    else()
+      message(FATAL_ERROR "cmake system ${CMAKE_SYSTEM_NAME} is not supported by conan. Use one of ${CONAN_SUPPORTED_PLATFORMS}")
+    endif()
   endif()
 
   if (${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)

--- a/conan.cmake
+++ b/conan.cmake
@@ -25,6 +25,14 @@ function(conan_cmake_settings result)
     message(FATAL_ERROR "Please specify in command line CMAKE_BUILD_TYPE (-DCMAKE_BUILD_TYPE=Release)")
   endif()
 
+  #handle -s os setting
+  set(CONAN_SUPPORTED_PLATFORMS Windows Linux Macos Android iOS FreeBSD)
+  if( CMAKE_SYSTEM_NAME IN_LIST CONAN_SUPPORTED_PLATFORMS )
+    set(_SETTINGS ${_SETTINGS} -s os=${CMAKE_SYSTEM_NAME})
+  else()
+    message(FATAL_ERROR "cmake system ${CMAKE_SYSTEM_NAME} is not supported by conan. Use one of ${CONAN_SUPPORTED_PLATFORMS}")
+  endif()
+
   if (${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
     # using GCC
     # TODO: Handle other params


### PR DESCRIPTION
Common cmake toolchain [files](https://github.com/jcupitt/build-win64/blob/master/8.2/Toolchain-x86_64-w64-mingw32.cmake) sets the CMAKE_SYSTEM_NAME. This one can be used as the conan os setting. This os detection is interesting for cross compiling workflows like mingw linux to windows compilation. 