### PR TITLE
Change CONAN_COMMAND argument to take multiple parameters

### DIFF
--- a/conan.cmake
+++ b/conan.cmake
@@ -145,8 +145,8 @@ endfunction()
 
 macro(parse_arguments)
   set(options BASIC_SETUP CMAKE_TARGETS)
-  set(oneValueArgs BUILD CONAN_COMMAND CONANFILE)
-  set(multiValueArgs REQUIRES OPTIONS IMPORTS)
+  set(oneValueArgs BUILD CONANFILE)
+  set(multiValueArgs REQUIRES OPTIONS IMPORTS CONAN_COMMAND)
   cmake_parse_arguments(ARGUMENTS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 endmacro()
 


### PR DESCRIPTION
I want to specify the location of conan, but I need to run conan.py via python explicitly in Windows:

```
conan_cmake_run(
    CONAN_COMMAND python E:\path\to\conan\conans\conan.py
    # other args
)
```

This doesn't work unless CONAN_COMMAND accepts multiple arguments.