### PR TITLE
fix  conan install  command in accordance with 1.0.0b2

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -19,6 +19,6 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     pyenv activate conan
 fi
 
-pip install conan
+pip install conan==1.0.0b2
 conan user
 pip install nose

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
 
 install:
   - set PATH=%PATH%;%PYTHON%/Scripts/
-  - pip.exe install conan nose
+  - pip.exe install conan==1.0.0b2 nose
 
 test_script:
   - nosetests .

--- a/conan.cmake
+++ b/conan.cmake
@@ -205,11 +205,13 @@ function(conan_cmake_install)
     endif()
     set(CONAN_OPTIONS "")
     if(ARGUMENTS_CONANFILE)
-      set(CONANFILE -f=${CMAKE_CURRENT_SOURCE_DIR}/${ARGUMENTS_CONANFILE})
+      set(CONANFILE ${CMAKE_CURRENT_SOURCE_DIR}/${ARGUMENTS_CONANFILE})
       # A conan file has been specified - apply specified options as well if provided
       foreach(ARG ${ARGUMENTS_OPTIONS})
           set(CONAN_OPTIONS ${CONAN_OPTIONS} -o ${ARG})
       endforeach()
+    else()
+      set(CONANFILE ".")
     endif()
     if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND ARGUMENTS_DEBUG_PROFILE)
       set(settings -pr ${ARGUMENTS_DEBUG_PROFILE})
@@ -253,7 +255,7 @@ endfunction()
 function(conan_cmake_generate_conanfile)
   # Generate, writing in disk a conanfile.txt with the requires, options, and imports
   # specified as arguments
-  # This will be considered as temporary file, generated in CMAKE_CURRENT_BINARY_DIR
+  # This will be considered as temporary file, generated in CMAKE_CURRENT_BINARY_DIR)
   parse_arguments(${ARGV})
   set(_FN "${CMAKE_CURRENT_BINARY_DIR}/conanfile.txt")
 

--- a/tests.py
+++ b/tests.py
@@ -144,7 +144,7 @@ add_executable(main main.cpp)
 target_link_libraries(main CONAN_PKG::Hello)
 """
         save("CMakeLists.txt", content)
-        self._build_multi()    
+        self._build_multi()
 
     def test_targets(self):
         content = """set(CMAKE_CXX_COMPILER_WORKS 1)
@@ -257,7 +257,7 @@ class Pkg(ConanFile):
         self.run('cmake . ' + cmake.command_line)
         self.run('cmake --build . ' + cmake.build_config)
         """)
-        run("conan export test/testing")
+        run("conan export . test/testing")
 
         os.makedirs("build")
         os.chdir("build")


### PR DESCRIPTION
1.0.0-beta changed `conan install` syntax to use `path/to/conanfile.txt` instead of `-f=path/to/conanfile.txt`; this small fix changes invokation of `conan install` during `conan_cmake_install` function.