### PR TITLE
Add WindowsStore to supported OS targets

### DIFF
--- a/conan.cmake
+++ b/conan.cmake
@@ -93,7 +93,7 @@ function(conan_cmake_settings result)
         if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
             set(CONAN_SYSTEM_NAME Macos)
         endif()
-        set(CONAN_SUPPORTED_PLATFORMS Windows Linux Macos Android iOS FreeBSD)
+        set(CONAN_SUPPORTED_PLATFORMS Windows Linux Macos Android iOS FreeBSD WindowsStore)
         list (FIND CONAN_SUPPORTED_PLATFORMS "${CONAN_SYSTEM_NAME}" _index)
         if (${_index} GREATER -1)
             #check if the cmake system is a conan supported one


### PR DESCRIPTION
This pull request addresses issue https://github.com/conan-io/cmake-conan/issues/107

**Description**

Support for UWP and WinRT are missing from the current conan.cmake but are both supported by CMake and conan.

This pull request adds the missing OS to CONAN_SUPPORTED_PLATFORMS 