### PR TITLE
Add DOWNLOAD_ONCE sub-command for CMake file()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@ project(conan_wrapper CXX)
 
 macro(file action)
     if(${action} STREQUAL DOWNLOAD_ONCE)
+        if(${ARGC} LESS 3)
+            # Too few arguments: show the standard error message
+            _file(DOWNLOAD ${ARGN})
+        endif ()
         if(NOT EXISTS ${ARGV2})
             message(STATUS "Downloading ${ARGV1}")
             _file(DOWNLOAD ${ARGN})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ macro(file action)
         if(${ARGC} LESS 3)
             # Too few arguments: show the standard error message
             _file(DOWNLOAD ${ARGN})
-        endif ()
+        endif()
         if(NOT EXISTS ${ARGV2})
             message(STATUS "Downloading ${ARGV1}")
             _file(DOWNLOAD ${ARGN})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,11 +18,10 @@ macro(file action)
 endmacro()
 
 
-# file(DOWNLOAD_ONCE "https://github.com/conan-io/cmake-conan/raw/master/conan.cmake"
-#                    "${CMAKE_BINARY_DIR}/conan.cmake")
+file(DOWNLOAD_ONCE "https://github.com/conan-io/cmake-conan/raw/master/conan.cmake"
+                   "${CMAKE_BINARY_DIR}/conan.cmake")
 
-# include(${CMAKE_BINARY_DIR}/conan.cmake)
-include(conan.cmake)
+include(${CMAKE_BINARY_DIR}/conan.cmake)
 conan_cmake_run(REQUIRES Hello/0.1@memsharded/testing
                 BASIC_SETUP CMAKE_TARGETS
                 BUILD missing)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,25 @@
 cmake_minimum_required(VERSION 2.8)
 project(conan_wrapper CXX)
 
-# if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
-#   message(STATUS "Downloading conan.cmake from https://github.com/memsharded/cmake-conan")
-#   file(DOWNLOAD "https://github.com/conan-io/cmake-conan/raw/master/conan.cmake"
-#                 "${CMAKE_BINARY_DIR}/conan.cmake")
-# endif()
+
+# Extend file() with DOWNLOAD_ONCE sub-command: download only
+# if there is no file with such name in the filesystem.
+
+macro(file action)
+    if(${action} STREQUAL DOWNLOAD_ONCE)
+        if(NOT EXISTS ${ARGV2})
+            message(STATUS "Downloading ${ARGV1}")
+            _file(DOWNLOAD ${ARGN})
+        endif()
+    else()
+        # Call the original function
+        _file(${action} ${ARGN})
+    endif()
+endmacro()
+
+
+# file(DOWNLOAD_ONCE "https://github.com/conan-io/cmake-conan/raw/master/conan.cmake"
+#                    "${CMAKE_BINARY_DIR}/conan.cmake")
 
 # include(${CMAKE_BINARY_DIR}/conan.cmake)
 include(conan.cmake)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ macro(file action)
         if(${ARGC} LESS 3)
             # Too few arguments: show the standard error message
             _file(DOWNLOAD ${ARGN})
-        endif ()
+        endif()
         if(NOT EXISTS ${ARGV2})
             message(STATUS "Downloading ${ARGV1}")
             _file(DOWNLOAD ${ARGN})

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ project(myproject CXX)
 
 macro(file action)
     if(${action} STREQUAL DOWNLOAD_ONCE)
+        if(${ARGC} LESS 3)
+            # Too few arguments: show the standard error message
+            _file(DOWNLOAD ${ARGN})
+        endif ()
         if(NOT EXISTS ${ARGV2})
             message(STATUS "Downloading ${ARGV1}")
             _file(DOWNLOAD ${ARGN})

--- a/README.md
+++ b/README.md
@@ -25,12 +25,25 @@ Or it can be used in this way. Note the ``v0.13`` tag in the URL, change it to p
 cmake_minimum_required(VERSION 2.8)
 project(myproject CXX)
 
+
+# Extend file() with DOWNLOAD_ONCE sub-command: download only
+# if there is no file with such name in the filesystem.
+
+macro(file action)
+    if(${action} STREQUAL DOWNLOAD_ONCE)
+        if(NOT EXISTS ${ARGV2})
+            message(STATUS "Downloading ${ARGV1}")
+            _file(DOWNLOAD ${ARGN})
+        endif()
+    else()
+        # Call the original function
+        _file(${action} ${ARGN})
+    endif()
+endmacro()
+
 # Download automatically, you can also just copy the conan.cmake file
-if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
-   message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
-   file(DOWNLOAD "https://github.com/conan-io/cmake-conan/raw/v0.13/conan.cmake"
-                 "${CMAKE_BINARY_DIR}/conan.cmake")
-endif()
+file(DOWNLOAD_ONCE "https://github.com/conan-io/cmake-conan/raw/v0.13/conan.cmake"
+                   "${CMAKE_BINARY_DIR}/conan.cmake")
 
 include(${CMAKE_BINARY_DIR}/conan.cmake)
 


### PR DESCRIPTION
Add reusable `file(DOWNLOAD_ONCE)` extension that works the same way `file(DOWNLOAD)` does, except it doesn't overwrite already existing files. Change `conan.cmake` download scenario from conditional `file(DOWNLOAD)` to `file(DOWNLOAD_ONCE)`.

Also uncommented the download of conan.cmake in CMakeLists.txt example. Is there a reason why local `conan.cmake` used?