### PR TITLE
add missing `=` in profile command line argument

### DIFF
--- a/conan.cmake
+++ b/conan.cmake
@@ -220,7 +220,7 @@ function(conan_cmake_settings result)
     endif()
 
     foreach(ARG ${_APPLIED_PROFILES})
-        set(_SETTINGS ${_SETTINGS} -pr ${ARG})
+        set(_SETTINGS ${_SETTINGS} -pr=${ARG})
     endforeach()
 
     if(NOT _SETTINGS OR ARGUMENTS_PROFILE_AUTO STREQUAL "ALL")


### PR DESCRIPTION
Adding this `=` after `-pr` enables the PROFILE passed to conan_cmake_run to be used. Previously (at least on my Windows test machine), the PROFILE was not taken into account and conan was running with the default profile. Now the profile used is the correct one.

Note: this makes the treatment of the `-pr` argument consistent with other conan.cmake-injected arguments such as `-g` or `--build`, which both have an `=` sign.