### PR TITLE
Fix compile_options before run compiler

### DIFF
--- a/conan.cmake
+++ b/conan.cmake
@@ -263,6 +263,7 @@ function(conan_cmake_detect_unix_libcxx result)
             endif()
         endif()
     endforeach()
+    string(GENEX_STRIP "${compile_options}" compile_options)
 
     execute_process(
         COMMAND ${CMAKE_COMMAND} -E echo "#include <string>"


### PR DESCRIPTION
I propose a fix for #182 

It will filter out all generator expressions before invoking compiler for automatic checking C++ STD library on UNIX