### PR TITLE
Add additional compiler options to conan_cmake_detect_unix_libcxx

### DIFF
--- a/conan.cmake
+++ b/conan.cmake
@@ -33,7 +33,7 @@
 # but it is only necessary on the end-user side. It is not necessary to create conan
 # packages, in fact it shouldn't be use for that. Check the project documentation.
 
-# version: 0.15.0-dev
+# version: 0.15.0
 
 include(CMakeParseArguments)
 

--- a/conan.cmake
+++ b/conan.cmake
@@ -251,9 +251,12 @@ endfunction()
 function(conan_cmake_detect_unix_libcxx result)
     # Take into account any -stdlib in compile options
     get_directory_property(compile_options DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMPILE_OPTIONS)
+    string(GENEX_STRIP "${compile_options}" compile_options)
 
     # Take into account any _GLIBCXX_USE_CXX11_ABI in compile definitions
     get_directory_property(defines DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMPILE_DEFINITIONS)
+    string(GENEX_STRIP "${defines}" defines)
+
     foreach(define ${defines})
         if(define MATCHES "_GLIBCXX_USE_CXX11_ABI")
             if(define MATCHES "^-D")


### PR DESCRIPTION
Without these many options many wrappers (e.g. ccache, winegcc) or cross-compiling toolchains (e.g. yocto) may not find the intended underlying tools and sysroot, leading to the command failing, or (perhaps worse) succeeding, but using defaults instead of the intended underlying gcc or libstdc++ and thus getting inaccurate results.

Fixes #182
Fixes #195 