### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ conan_add_remote(NAME bincrafters INDEX 1
 
 ### conan_config_install()
 
-Adds a remote.
+Installs a full configuration from a local or remote zip file.
 Argument ``ITEM`` is required,  arguments ``TYPE``, ``SOURCE``, ``TARGET`` and ``VERIFY_SSL`` are optional.
 
 Example usage:


### PR DESCRIPTION
I was reading the readme file to see how to use conan-cmake and I came across an error on the description of conan_config_install() description. Looks like a copy/paste of conan_remote_install() caused this.

I took the description from inside conan.cmake and put it on the readme.