### PR TITLE
Finding conanbuildinfo in either CMAKE_BINARY_DIR or CMAKE_CURRENT_BINARY_DIR

### DIFF
--- a/conan.cmake
+++ b/conan.cmake
@@ -453,7 +453,10 @@ macro(conan_load_buildinfo)
     if(ARGUMENTS_INSTALL_FOLDER)
         set(_CONANBUILDINFOFOLDER ${ARGUMENTS_INSTALL_FOLDER})
     else()
-        set(_CONANBUILDINFOFOLDER ${CMAKE_CURRENT_BINARY_DIR})
+        find_path(_CONANBUILDINFOFOLDER 
+        NAMES ${_CONANBUILDINFO} 
+        PATHS ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}
+        NO_DEFAULT_PATH)
     endif()
     # Checks for the existence of conanbuildinfo.cmake, and loads it
     # important that it is macro, so variables defined at parent scope


### PR DESCRIPTION
If a project is using cmake-conan in a CMakeLists.txt that is not the root-CMakeLists included using `add_subdirectory(...)` this might cause the build to fail on some plattforms (testted windows using msvc).  
The underlying problem is that a pure cmake build will put the `conanbuildinfo.cmake` into the relative path in the build folder while if the build is invoked using `conan create` the buildinfo file is in the root of the build folder. 

The problem might be with conan itself, but having multiple possible options to look for will fix the problem as well. 

See [SI](https://github.com/bernedom/SI) for an example of the setup I'm referring to. 