### PR TITLE
Fixing CI builds by updating python and cmake_installer

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,12 +2,12 @@ build: false
 image: Visual Studio 2017
 
 environment:
-    PYTHON: "C:\\Python27"
-    PYTHON_VERSION: "2.7.8"
-    PYTHON_ARCH: "32"
+  PYTHON: "C:\\Python37"
+  PYTHON_VERSION: "3.7.5"
+  PYTHON_ARCH: "32"
 
 install:
-  - set PATH=%PATH%;%PYTHON%/Scripts/
+  - set PATH=%PYTHON%/Scripts/;%PYTHON;%PATH%;
   - pip.exe install conan nose
   - conan install cmake_installer/3.7.2@conan/stable -g=virtualrunenv
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,9 @@ environment:
   PYTHON_ARCH: "32"
 
 install:
-  - set PATH=%PYTHON%/Scripts/;%PYTHON;%PATH%;
+  - set PATH=%PYTHON%/Scripts/;%PYTHON%;%PATH%
   - pip.exe install conan nose
-  - conan install cmake_installer/3.7.2@conan/stable -g=virtualrunenv
+  - conan install cmake_installer/3.16.3@conan/stable -g=virtualrunenv
 
 test_script:
   - activate_run.bat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
 install:
   - set PATH=%PYTHON%/Scripts/;%PYTHON%;%PATH%
   - pip.exe install conan nose
-  - conan install cmake_installer/3.16.3@conan/stable -g=virtualrunenv
+  - conan install cmake_installer/3.16.4@ -g=virtualrunenv
 
 test_script:
   - activate_run.bat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
 install:
   - set PATH=%PYTHON%/Scripts/;%PYTHON%;%PATH%
   - pip.exe install conan nose
-  - conan install cmake_installer/3.16.4@ -g=virtualrunenv
+  - conan install cmake/3.16.4@ -g=virtualrunenv
 
 test_script:
   - activate_run.bat


### PR DESCRIPTION
The current appveyor build is still using python 2.7. which is deprecated and caused the build to hang, because conan now wants interactive confirmation that this is OK. 

By updating to python 3.7.5 and cmake_installer 3.16 it runs through again 