### PR TITLE
fixed argument parsing in conan_config_install

### DIFF
--- a/conan.cmake
+++ b/conan.cmake
@@ -578,7 +578,6 @@ macro(conan_config_install)
     set(oneValueArgs ITEM TYPE SOURCE TARGET VERIFY_SSL)
     set(multiValueArgs ARGS)
     cmake_parse_arguments(CONAN "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-    set(CONAN_CONFIG_INSTALL_ARGS "")
 
     find_program(CONAN_CMD conan)
     if(NOT CONAN_CMD AND CONAN_REQUIRED)
@@ -586,25 +585,31 @@ macro(conan_config_install)
     endif()
 
     if(DEFINED CONAN_VERIFY_SSL)
-        set(CONAN_CONFIG_INSTALL_ARGS "${CONAN_CONFIG_INSTALL_ARGS} --verify-ssl ${CONAN_VERIFY_SSL}")
+	set(CONAN_VERIFY_SSL_ARG "--verify-ssl=${CONAN_VERIFY_SSL}")
     endif()
 
     if(DEFINED CONAN_TYPE)
-        set(CONAN_CONFIG_INSTALL_ARGS "${CONAN_CONFIG_INSTALL_ARGS} --type ${CONAN_TYPE}")
+	set(CONAN_TYPE_ARG "--type=${CONAN_TYPE}")
     endif()
 
     if(DEFINED CONAN_ARGS)
-        set(CONAN_CONFIG_INSTALL_ARGS "${CONAN_CONFIG_INSTALL_ARGS} --args \"${CONAN_ARGS}\"")
+	set(CONAN_ARGS_ARGS "--args=\"${CONAN_ARGS}\"")
     endif()
 
     if(DEFINED CONAN_SOURCE)
-        set(CONAN_CONFIG_INSTALL_ARGS "${CONAN_CONFIG_INSTALL_ARGS} --source-folder ${CONAN_SOURCE}")
+	set(CONAN_SOURCE_ARGS "--source-folder=${CONAN_SOURCE}")
     endif()
 
     if(DEFINED CONAN_TARGET)
-        set(CONAN_CONFIG_INSTALL_ARGS "${CONAN_CONFIG_INSTALL_ARGS} --target-folder ${CONAN_TARGET}")
+	set(CONAN_TARGET_ARGS "--target-folder=${CONAN_TARGET}")
     endif()
 
+    set (CONAN_CONFIG_INSTALL_ARGS 	${CONAN_VERIFY_SSL_ARG}
+					${CONAN_TYPE_ARG}
+					${CONAN_ARGS_ARGS}
+					${CONAN_SOURCE_ARGS}
+					${CONAN_TARGET_ARGS})
+
     message(STATUS "Conan: Installing config from ${CONAN_ITEM}")
-    execute_process(COMMAND ${CONAN_CMD} config install ${CONAN_CONFIG_INSTALL_ARGS} ${CONAN_ITEM})
+	execute_process(COMMAND ${CONAN_CMD} config install ${CONAN_ITEM} ${CONAN_CONFIG_INSTALL_ARGS})
 endmacro()

--- a/tests.py
+++ b/tests.py
@@ -436,7 +436,7 @@ class CMakeConanTest(unittest.TestCase):
 
             set(CONAN_DISABLE_CHECK_COMPILER ON)
             include(conan.cmake)
-            conan_config_install(ITEM \"${PROJECT_SOURCE_DIR}/config/\")
+            conan_config_install(ITEM \"${PROJECT_SOURCE_DIR}/config/\" VERIFY_SSL false)
         """)
 
         save("config/remotes.txt", "%s %s %r" % (remote_name, remote_url, verify_ssl))


### PR DESCRIPTION
I had to modify the macro conan_config_install to be able to parse arguments properly. Otherwise conan config install will not work as soon as there are more parameters than ITEM.