### PR TITLE
silence macos warning

### DIFF
--- a/conan.cmake
+++ b/conan.cmake
@@ -264,6 +264,13 @@ function(conan_cmake_detect_unix_libcxx result)
         endif()
     endforeach()
 
+    if (APPLE)
+        # ensure that <string> can include <string.h>
+        if (IS_DIRECTORY /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include)
+            set(compile_options "${compile_option}" "-I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/")
+        endif()
+    endif()
+
     execute_process(
         COMMAND ${CMAKE_COMMAND} -E echo "#include <string>"
         COMMAND ${CMAKE_CXX_COMPILER} -x c++ ${compile_options} -E -dM -


### PR DESCRIPTION
i was running into this compiler invocation error on two different macos computers. the error seems harmless, but nevertheless it's ugly and confuses devs.

i don't exactly like the fix of adding an implicit preprocessor path, but otoh the change is not very intrusive. thoughts?

----

on macos we are running into the following warning when trying to run
the system autodetection:

```
/Applications/Xcode11.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/string.h:61:15:
fatal error: 'string.h' file not
      found
              ^~~~~~~~~~
```

it seems that the compiler cannot find the sdk root, so the c++ headers
cannot find the c headers. we therefore add the macos sdk path manually