### PR TITLE
Fix for cmake-conan issue #225 - Compile error on configuration on MacOS

### DIFF
--- a/conan.cmake
+++ b/conan.cmake
@@ -264,9 +264,13 @@ function(conan_cmake_detect_unix_libcxx result)
         endif()
     endforeach()
 
+    if(APPLE)
+        set(xcode_sysroot_option "--sysroot=${CMAKE_OSX_SYSROOT}")
+    endif()
+
     execute_process(
         COMMAND ${CMAKE_COMMAND} -E echo "#include <string>"
-        COMMAND ${CMAKE_CXX_COMPILER} -x c++ ${compile_options} -E -dM -
+        COMMAND ${CMAKE_CXX_COMPILER} -x c++ ${xcode_sysroot_option} ${compile_options} -E -dM -
         OUTPUT_VARIABLE string_defines
     )
 

--- a/conan.cmake
+++ b/conan.cmake
@@ -264,7 +264,7 @@ function(conan_cmake_detect_unix_libcxx result)
         endif()
     endforeach()
 
-    if(APPLE)
+    if(CMAKE_OSX_SYSROOT)
         set(xcode_sysroot_option "--sysroot=${CMAKE_OSX_SYSROOT}")
     endif()
 

--- a/tests.py
+++ b/tests.py
@@ -48,6 +48,30 @@ class CMakeConanTest(unittest.TestCase):
         os.environ.clear()
         os.environ.update(self.old_env)
 
+    # https://github.com/conan-io/cmake-conan/issues/159
+    @unittest.skipIf(platform.system() != "Darwin", "Error message appears just in Macos")
+    def test_macos_sysroot_warning(self):
+        content = textwrap.dedent("""
+            cmake_minimum_required(VERSION 2.8)
+            project(FormatOutput CXX)
+            set(CMAKE_CXX_STANDARD 11)
+            include(conan.cmake)
+            conan_cmake_run(REQUIRES fmt/6.1.2
+                            BASIC_SETUP
+                            BUILD missing)
+
+            add_executable(main main.cpp)
+            target_link_libraries(main ${CONAN_LIBS})
+        """)
+        save("CMakeLists.txt", content)
+
+        os.makedirs("build")
+        os.chdir("build")
+        run("cmake .. %s -DCMAKE_BUILD_TYPE=Release 2> stderr_output.txt" % generator)
+        with open('stderr_output.txt', 'r') as file:
+            data = file.read()
+            assert "#include_next <string.h>" not in data
+
     def test_global_update(self):
         content = """set(CMAKE_CXX_COMPILER_WORKS 1)
 set(CMAKE_CXX_ABI_COMPILED 1)


### PR DESCRIPTION
The sysroot option is not set when using `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++`, needs to be added explicitly.

Closes: https://github.com/conan-io/cmake-conan/issues/159
Closes: https://github.com/conan-io/cmake-conan/issues/225