### PR TITLE
Add VERIFY_SSL arg to conan_add_remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,12 +256,14 @@ conan_check(VERSION 1.0.0 REQUIRED)
 ### conan_add_remote()
 
 Adds a remote.
-Arguments ``URL`` and ``NAME`` are required, ``INDEX`` is optional.
+Arguments ``URL`` and ``NAME`` are required, ``INDEX`` and ``VERIFY_SSL`` are optional.
 
 Example usage:
 ```
-conan_add_remote(NAME bincrafters INDEX 1
-            URL https://api.bintray.com/conan/bincrafters/public-conan)
+conan_add_remote(NAME bincrafters 
+                 INDEX 1
+                 URL https://api.bintray.com/conan/bincrafters/public-conan
+                 VERIFY_SSL True)            
 ```
 
 ### conan_config_install()

--- a/conan.cmake
+++ b/conan.cmake
@@ -549,24 +549,28 @@ endmacro()
 
 function(conan_add_remote)
     # Adds a remote
-    # Arguments URL and NAME are required, INDEX and COMMAND are optional
+    # Arguments URL and NAME are required, INDEX, COMMAND and VERIFY_SSL are optional
     # Example usage:
     #    conan_add_remote(NAME bincrafters INDEX 1
-    #       URL https://api.bintray.com/conan/bincrafters/public-conan)
-    set(oneValueArgs URL NAME INDEX COMMAND)
+    #       URL https://api.bintray.com/conan/bincrafters/public-conan
+    #       VERIFY_SSL True)
+    set(oneValueArgs URL NAME INDEX COMMAND VERIFY_SSL)
     cmake_parse_arguments(CONAN "" "${oneValueArgs}" "" ${ARGN})
 
     if(DEFINED CONAN_INDEX)
         set(CONAN_INDEX_ARG "-i ${CONAN_INDEX}")
     endif()
-    if(CONAN_COMMAND)
-       set(CONAN_CMD ${CONAN_COMMAND})
+    if(DEFINED CONAN_COMMAND)
+        set(CONAN_CMD ${CONAN_COMMAND})
     else()
         conan_check(REQUIRED)
     endif()
-    message(STATUS "Conan: Adding ${CONAN_NAME} remote repository (${CONAN_URL})")
-    execute_process(COMMAND ${CONAN_CMD} remote add ${CONAN_NAME} ${CONAN_URL}
-      ${CONAN_INDEX_ARG} -f)
+    set(CONAN_VERIFY_SSL_ARG "True")
+    if(DEFINED CONAN_VERIFY_SSL)
+        set(CONAN_VERIFY_SSL_ARG ${CONAN_VERIFY_SSL})
+    endif()
+    message(STATUS "Conan: Adding ${CONAN_NAME} remote repository (${CONAN_URL}) verify ssl (${CONAN_VERIFY_SSL_ARG})")
+    execute_process(COMMAND ${CONAN_CMD} remote add ${CONAN_NAME} ${CONAN_INDEX_ARG} -f ${CONAN_URL} ${CONAN_VERIFY_SSL_ARG})
 endfunction()
 
 macro(conan_config_install)

--- a/tests.py
+++ b/tests.py
@@ -47,6 +47,26 @@ class CMakeConanTest(unittest.TestCase):
         os.environ.clear()
         os.environ.update(self.old_env)
 
+    def test_conan_add_remote(self):
+        content = textwrap.dedent("""
+            cmake_minimum_required(VERSION 2.8)
+            project(FormatOutput CXX)
+            include(conan.cmake)            
+            conan_add_remote(NAME someremote 
+                             INDEX 0 
+                             URL http://someremote
+                             VERIFY_SSL False)
+        """)
+        save("CMakeLists.txt", content)
+        os.makedirs("build")
+        os.chdir("build")
+        run("cmake .. %s -DCMAKE_BUILD_TYPE=Release" % generator)
+        run("conan remote list > output_remotes.txt")
+        with open('output_remotes.txt', 'r') as file:
+            data = file.read()
+            print(data)
+            assert "someremote: http://someremote [Verify SSL: False]" in data      
+
     def test_global_update(self):
         content = textwrap.dedent("""
             set(CMAKE_CXX_COMPILER_WORKS 1)

--- a/tests.py
+++ b/tests.py
@@ -64,7 +64,6 @@ class CMakeConanTest(unittest.TestCase):
         run("conan remote list > output_remotes.txt")
         with open('output_remotes.txt', 'r') as file:
             data = file.read()
-            print(data)
             assert "someremote: http://someremote [Verify SSL: False]" in data      
 
     def test_global_update(self):


### PR DESCRIPTION
This adds a VERIFY_SSL argument to the conan_add_remote function (We have a local conan repository that requires the verify ssl argument be false)
