### PR TITLE
use stdlib clang flag to check libcxx

### DIFF
--- a/conan.cmake
+++ b/conan.cmake
@@ -264,6 +264,14 @@ function(conan_cmake_detect_unix_libcxx result)
         endif()
     endforeach()
 
+    if (${CMAKE_${LANGUAGE}_COMPILER_ID} STREQUAL AppleClang OR ${CMAKE_${LANGUAGE}_COMPILER_ID} STREQUAL Clang)
+        foreach(cxx_flag ${CMAKE_CXX_FLAGS})
+            if(cxx_flag MATCHES "stdlib")
+                set(compile_options ${compile_options} ${cxx_flag})
+            endif()
+        endforeach()
+    endif()
+
     execute_process(
         COMMAND ${CMAKE_COMMAND} -E echo "#include <string>"
         COMMAND ${CMAKE_CXX_COMPILER} -x c++ ${compile_options} -E -dM -


### PR DESCRIPTION
When trying to detect the `libcxx` setting for conan if using clang you can set the `-stdlib` flag to `libc++` or `libdstdc++` but that was not being taken into account if the flag was set using `CMAKE_CXX_FLAGS` (but it was used if the flag was set with `add_compile_options`) 

Fixes: #229
