### PR TITLE
Take CMAKE_CXX_FLAGS into account when detecting libcxx

### DIFF
--- a/conan.cmake
+++ b/conan.cmake
@@ -264,9 +264,13 @@ function(conan_cmake_detect_unix_libcxx result)
         endif()
     endforeach()
 
+    # Take into account any compilation flags (e.g. --sysroot)
+    set(compile_flags ${CMAKE_CXX_FLAGS})
+    separate_arguments(compile_flags)
+
     execute_process(
         COMMAND ${CMAKE_COMMAND} -E echo "#include <string>"
-        COMMAND ${CMAKE_CXX_COMPILER} -x c++ ${compile_options} -E -dM -
+        COMMAND ${CMAKE_CXX_COMPILER} -x c++ ${compile_flags} ${compile_options} -E -dM -
         OUTPUT_VARIABLE string_defines
     )
 


### PR DESCRIPTION
Hi! We're building for some obscure embedded platforms using sysroots and ran into an issue where conan fails to find string when trying to autodetect libcxx as it doesn't care about the CXX_FLAGS (where we pass --sysroot).

Just passing `${CMAKE_CXX_FLAGS}` doesn't work since the compiler will get "-m32 --sysroot=..." as 1 argument instead of two, so I had to split them using separate_arguments.