### PR TITLE
Remove manually specified settings from auto list

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,10 @@ environment:
 install:
   - set PATH=%PYTHON%/Scripts/;%PYTHON%;%PATH%
   - pip.exe install conan nose
+  - conan install cmake/3.16.4@ -g=virtualrunenv
 
 test_script:
+  - activate_run.bat
   - nosetests . -A "not cmake39"
+  - deactivate_run.bat
   - nosetests . -A "cmake39"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,10 +9,8 @@ environment:
 install:
   - set PATH=%PYTHON%/Scripts/;%PYTHON%;%PATH%
   - pip.exe install conan nose
-  - conan install cmake/3.16.4@ -g=virtualrunenv
 
 test_script:
-  - activate_run.bat
   - nosetests . -A "not cmake39"
   - deactivate_run.bat
   - nosetests . -A "cmake39"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,5 +12,4 @@ install:
 
 test_script:
   - nosetests . -A "not cmake39"
-  - deactivate_run.bat
   - nosetests . -A "cmake39"

--- a/conan.cmake
+++ b/conan.cmake
@@ -229,6 +229,13 @@ function(conan_cmake_settings result)
                                    compiler.runtime compiler.libcxx compiler.toolset)
     endif()
 
+    # remove any manually specified settings from the autodetected settings
+    foreach(ARG ${ARGUMENTS_SETTINGS})
+        string(REGEX MATCH "[^=]*" MANUAL_SETTING "${ARG}")
+        message(STATUS "Conan: ${MANUAL_SETTING} was added as an argument. Not using the autodetected one.")
+        list(REMOVE_ITEM ARGUMENTS_PROFILE_AUTO "${MANUAL_SETTING}")
+    endforeach()    
+
     # Automatic from CMake
     foreach(ARG ${ARGUMENTS_PROFILE_AUTO})
         string(TOUPPER ${ARG} _arg_name)

--- a/tests.py
+++ b/tests.py
@@ -304,7 +304,7 @@ class CMakeConanTest(unittest.TestCase):
             include(conan.cmake)
             conan_cmake_run(BASIC_SETUP
                             SETTINGS {})
-            STRING(REGEX MATCHALL "compiler.libcxx" matches "${{settings}}")
+            STRING(REGEX MATCHALL "{}" matches "${{settings}}")
             list(LENGTH matches n_matches)
             if(NOT n_matches EQUAL 1)
                 message(FATAL_ERROR "CONAN_SETTINGS DUPLICATED!")

--- a/tests.py
+++ b/tests.py
@@ -310,7 +310,6 @@ class CMakeConanTest(unittest.TestCase):
                 message(FATAL_ERROR "CONAN_SETTINGS DUPLICATED!")
             endif()            
         """.format(custom_setting, settings_check))
-        print(content)
         save("CMakeLists.txt", content)
 
         os.makedirs("build")


### PR DESCRIPTION
Manual settings were added in the end to automatic CMake settings, so they were not taken into account because only the first one was considered by CMake.
This PR removes the MANUAL settings from the AUTO list of added settings from CMake so that they are not added twice.

Fixes: #255 