### PR TITLE
Make error message more actionable

### DIFF
--- a/conan.cmake
+++ b/conan.cmake
@@ -528,7 +528,7 @@ macro(conan_check)
 
     find_program(CONAN_CMD conan)
     if(NOT CONAN_CMD AND CONAN_REQUIRED)
-        message(FATAL_ERROR "Conan executable not found!")
+        message(FATAL_ERROR "Conan executable not found! Please install conan.")
     endif()
     message(STATUS "Conan: Found program ${CONAN_CMD}")
     execute_process(COMMAND ${CONAN_CMD} --version


### PR DESCRIPTION
This is a change I made to the local copy of conan.cmake in my repository so that users who try to install my project (and possibly don't know what conan is) get a more actionable error message and some pointers of what they have to do to fix it.