### PR TITLE
Skip generic os check when CMAKE_SYSTEM_NAME is set to generic

### DIFF
--- a/conan.cmake
+++ b/conan.cmake
@@ -97,7 +97,7 @@ function(conan_cmake_settings result)
         set(_CONAN_SETTING_ARCH ${ARGUMENTS_ARCH})
     endif()
     #handle -s os setting
-    if(CMAKE_SYSTEM_NAME)
+    if(CMAKE_SYSTEM_NAME AND NOT CMAKE_SYSTEM_NAME STREQUAL "Generic")
         #use default conan os setting if CMAKE_SYSTEM_NAME is not defined
         set(CONAN_SYSTEM_NAME ${CMAKE_SYSTEM_NAME})
         if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")


### PR DESCRIPTION
This PR is intended to unblock users that are targeting a platform that may not have os, or that is set as Generic in the CMaketoolchain file.

Closes: https://github.com/conan-io/cmake-conan/issues/245
Closes: https://github.com/conan-io/cmake-conan/issues/150
Related to: https://github.com/conan-io/cmake-conan/issues/284 