### PR TITLE
Added conan.cmake file version check & download error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ add_definitions("-std=c++11")
 
 if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
   message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
-  file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/v0.16.1/conan.cmake"
+  file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/0.17.0/conan.cmake"
                 "${CMAKE_BINARY_DIR}/conan.cmake"
-                EXPECTED_HASH SHA256=396e16d0f5eabdc6a14afddbcfff62a54a7ee75c6da23f32f7a31bc85db23484
+                EXPECTED_HASH SHA256=3bef79da16c2e031dc429e1dac87a08b9226418b300ce004cc125a82687baeef
                 TLS_VERIFY ON)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,35 @@ list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR})
 
 add_definitions("-std=c++11")
 
+set (CONAN_CMAKE_VERSION "0.17.0")
+set (CONAN_CMAKE_HASH 3bef79da16c2e031dc429e1dac87a08b9226418b300ce004cc125a82687baeef)
+
+set (DOWNLOAD_CONAN_CMAKE false)
+
 if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
+  set (DOWNLOAD_CONAN_CMAKE true)
+else()
+  message(STATUS "Checking version of existing conan.cmake file")
+  file(READ "${CMAKE_BINARY_DIR}/conan.cmake" FILE_CONTENTS)
+  string(FIND "${FILE_CONTENTS}" "# version: ${CONAN_CMAKE_VERSION}" MATCH_RESULT)
+
+  if(${MATCH_RESULT} EQUAL -1)
+    set (DOWNLOAD_CONAN_CMAKE true)
+  endif()
+endif()
+
+if (${DOWNLOAD_CONAN_CMAKE})
   message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
-  file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/0.17.0/conan.cmake"
-                "${CMAKE_BINARY_DIR}/conan.cmake"
-                EXPECTED_HASH SHA256=3bef79da16c2e031dc429e1dac87a08b9226418b300ce004cc125a82687baeef
-                TLS_VERIFY ON)
+  file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/${CONAN_CMAKE_VERSION}/conan.cmake"
+    "${CMAKE_BINARY_DIR}/conan.cmake"
+    EXPECTED_HASH SHA256=${CONAN_CMAKE_HASH}
+    TLS_VERIFY ON
+    STATUS DOWNLOAD_STATUS)
+
+  list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
+  if(NOT ${STATUS_CODE} EQUAL 0)
+    message(FATAL_ERROR "Error downloading conan.cmake: ${DOWNLOAD_STATUS}")
+  endif()
 endif()
 
 include(${CMAKE_BINARY_DIR}/conan.cmake)


### PR DESCRIPTION
The current version of the conan.cmake file download in the readme is just a simple check that the file exists.  This is problematic if a developer has an outdated version of the file present on their machine and can result in vague error messages later in the process.  I've added logic to parse the version number from the file present on their machine and compare with the version in their CMakeLists.txt.

I've also added logic to catch file download errors as errors were previously either ignored or a misleading error message was shown.

Finally, I've updated the conan.cmake file version number to 0.17.0 avoid errors for Visual Studio 2022 users following the readme.