### PR TITLE
Detect ClangCL correctly on Visual Studio Clang builds

### DIFF
--- a/conan.cmake
+++ b/conan.cmake
@@ -170,7 +170,10 @@ macro(_conan_detect_compiler)
             conan_cmake_detect_unix_libcxx(_LIBCXX)
             set(_CONAN_SETTING_COMPILER_LIBCXX ${_LIBCXX})
         endif ()
-    elseif (${CMAKE_${LANGUAGE}_COMPILER_ID} STREQUAL Clang)
+    elseif (${CMAKE_${LANGUAGE}_COMPILER_ID} STREQUAL Clang
+                AND NOT "${CMAKE_${LANGUAGE}_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC" 
+                AND NOT "${CMAKE_${LANGUAGE}_SIMULATE_ID}" STREQUAL "MSVC")
+
         string(REPLACE "." ";" VERSION_LIST ${CMAKE_${LANGUAGE}_COMPILER_VERSION})
         list(GET VERSION_LIST 0 MAJOR)
         list(GET VERSION_LIST 1 MINOR)
@@ -190,7 +193,11 @@ macro(_conan_detect_compiler)
             conan_cmake_detect_unix_libcxx(_LIBCXX)
             set(_CONAN_SETTING_COMPILER_LIBCXX ${_LIBCXX})
         endif ()
-    elseif(${CMAKE_${LANGUAGE}_COMPILER_ID} STREQUAL MSVC)
+    elseif(${CMAKE_${LANGUAGE}_COMPILER_ID} STREQUAL MSVC
+                OR (${CMAKE_${LANGUAGE}_COMPILER_ID} STREQUAL Clang 
+                    AND "${CMAKE_${LANGUAGE}_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC" 
+                    AND "${CMAKE_${LANGUAGE}_SIMULATE_ID}" STREQUAL "MSVC"))
+
         set(_VISUAL "Visual Studio")
         _get_msvc_ide_version(_VISUAL_VERSION)
         if("${_VISUAL_VERSION}" STREQUAL "")


### PR DESCRIPTION
CMake-conan currently recognizes ClangCL (Clang with cl.exe interface and MSVC ABI) as regular Clang (with GCC interface and ABI), consequently failing builds.

I added an exclusion to remove ClangCL from the "regular" Clang category and an inclusion to add ClangCL to the Visual Studio category. This works for building directly from Visual Studio, with the ClangCL toolset.

Limitations:
- Building with Clang with GNU interface and MSVC ABI is still undefined behaviour
- Building with Clang with cl.exe interface and GNU/MinGW ABI is still undefined (I don't know if such a flavour even exists)
- The failure was that conan originally picked MinGW Makefiles for Clang. I suppose now it picks Visual Studio solutions. I don't suppose it's possible to build with Clang/MSVC ABI without the MSVC toolset being installed, but if it is, that might be a problem.

Just let me know how we can improve the PR or if there are other plans to resolve the issue.