### PR TITLE
Add Conan as a possible program name in conan_check

### DIFF
--- a/conan.cmake
+++ b/conan.cmake
@@ -797,7 +797,7 @@ macro(conan_check)
         message(STATUS "Conan: checking conan executable")
     endif()
 
-    find_program(CONAN_CMD conan)
+    find_program(CONAN_CMD conan Conan)
     if(NOT CONAN_CMD AND CONAN_REQUIRED)
         message(FATAL_ERROR "Conan executable not found! Please install conan.")
     endif()


### PR DESCRIPTION
This commit extends the `find_program` to also look for `Conan` in addition to `conan`.
The reason for this change is, that conan is named `Conan` when installed with winget.