### PR TITLE
Restore detection of target OS

### DIFF
--- a/conan.cmake
+++ b/conan.cmake
@@ -280,7 +280,7 @@ function(conan_cmake_settings result)
 
     if(NOT _SETTINGS OR ARGUMENTS_PROFILE_AUTO STREQUAL "ALL")
         set(ARGUMENTS_PROFILE_AUTO arch build_type compiler compiler.version
-                                   compiler.runtime compiler.libcxx compiler.toolset)
+                                   compiler.runtime compiler.libcxx compiler.toolset os)
     endif()
 
     # remove any manually specified settings from the autodetected settings
@@ -429,7 +429,7 @@ endfunction()
 function(_collect_settings result)
     set(ARGUMENTS_PROFILE_AUTO arch build_type compiler compiler.version
                             compiler.runtime compiler.libcxx compiler.toolset
-                            compiler.cppstd)
+                            compiler.cppstd os)
     foreach(ARG ${ARGUMENTS_PROFILE_AUTO})
         string(TOUPPER ${ARG} _arg_name)
         string(REPLACE "." "_" _arg_name ${_arg_name})

--- a/tests.py
+++ b/tests.py
@@ -86,7 +86,7 @@ class CMakeConanTest(unittest.TestCase):
         run("cmake .. {} -DCMAKE_BUILD_TYPE=Release > output.txt".format(generator))
         with open('output.txt', 'r') as file:
             data = file.read()
-            the_os = {'Darwin': 'Macos'}.get(platform.system())
+            the_os = {'Darwin': 'Macos'}.get(platform.system(), platform.system())
             assert f"os={the_os}" in data
 
     # https://github.com/conan-io/cmake-conan/issues/279

--- a/tests.py
+++ b/tests.py
@@ -60,7 +60,7 @@ class CMakeConanTest(unittest.TestCase):
         os.environ.update(self.old_env)
 
     # https://github.com/conan-io/cmake-conan/pull/420
-    def test_conan_cmake_autodetect_cxx_os(self):
+    def test_conan_cmake_autodetect_os(self):
         content = textwrap.dedent("""
             cmake_minimum_required(VERSION 3.9)
             project(FormatOutput CXX)


### PR DESCRIPTION
This was broken in 61ae3b3356f2f2c6ca2a3dd0fedcc21a407bbe1c. The variable is getting set correctly, but it was never added to the actual settings.