### PR TITLE
conan config install uses the args as multiple arguments and passes them correctly to git

### DIFF
--- a/conan.cmake
+++ b/conan.cmake
@@ -1004,7 +1004,9 @@ macro(conan_config_install)
     endif()
 
     if(DEFINED CONAN_ARGS)
-	set(CONAN_ARGS_ARGS "--args=\"${CONAN_ARGS}\"")
+	# Convert ; seperated multi arg list into space seperated string
+	string(REPLACE ";" " " l_CONAN_ARGS "${CONAN_ARGS}")
+	set(CONAN_ARGS_ARGS "--args=${l_CONAN_ARGS}")
     endif()
 
     if(DEFINED CONAN_SOURCE)

--- a/tests.py
+++ b/tests.py
@@ -831,6 +831,29 @@ class CMakeConanTest(unittest.TestCase):
             assert remote["url"] == remote_url, "Invalid remote url"
             assert remote["verify_ssl"] == verify_ssl, "Invalid verify_ssl"
 
+    def test_conan_config_install_args(self):
+        content = textwrap.dedent("""
+            cmake_minimum_required(VERSION 3.9)
+            project(FormatOutput CXX)
+            message(STATUS "CMAKE VERSION: ${CMAKE_VERSION}")
+
+            set(CONAN_DISABLE_CHECK_COMPILER ON)
+            include(conan.cmake)
+            conan_config_install(ITEM https://github.com/conan-io/cmake-conan.git
+                                 TYPE git
+                                 ARGS -b v0.5)
+        """)
+        save("CMakeLists.txt", content)
+        os.makedirs("build")
+        os.chdir("build")
+
+        run("cmake .. {} -DCMAKE_BUILD_TYPE=Release > output.txt".format(generator))
+        with open('output.txt', 'r') as file:
+            data = file.read()
+            assert "Repo cloned!" in data
+            assert "Copying file" in data
+
+
 class LocalTests(unittest.TestCase):
 
     @classmethod


### PR DESCRIPTION
Hi, 
I slightly changed the behavior of `conan_config_install()`, when using ARGS. This problem is also mentioned in https://github.com/conan-io/cmake-conan/issues/333.
`conan config install()` uses now a space seperated list and passes it correctly to conan/git:
e.g. `conan_config_install(ITEM https://github.com/conan-io/cmake-conan.git
                                 TYPE git
                                 ARGS -b v0.5)`
Moreover I introduced a unit test, which shows the intended behavior.

Please discuss, if this change is okay. 

Thank you,
Martin