### PR TITLE
Add 'conan_version()' function to get the Conan client version

### DIFF
--- a/.github/workflows/cmake_conan.yml
+++ b/.github/workflows/cmake_conan.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Install Conan
         run: pip install conan pytest && conan --version
       - name: Install CMake
-        run: conan install cmake/3.16.4@ -g=virtualrunenv
+        run: conan install cmake/3.16.9@ -g=virtualrunenv
       - name: Run Tests
         run: ${{matrix.ENV_CMAKE}} && pytest tests.py -rA -v

--- a/.github/workflows/cmake_conan.yml
+++ b/.github/workflows/cmake_conan.yml
@@ -7,11 +7,8 @@ jobs:
         os: [windows-2019, macos-latest, ubuntu-latest]
         include:
           - os: windows-2019
-            ENV_CMAKE: ./activate_run.ps1
           - os: macos-latest
-            ENV_CMAKE: source activate_run.sh
           - os: ubuntu-latest
-            ENV_CMAKE: source activate_run.sh
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -20,7 +17,9 @@ jobs:
           python-version: 3.7
       - name: Install Conan
         run: pip install conan pytest && conan --version
-      - name: Install CMake
-        run: conan install cmake/3.16.9@ -g=virtualrunenv
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v1.13
+        with:
+          cmake-version: '3.16.x'
       - name: Run Tests
-        run: ${{matrix.ENV_CMAKE}} && pytest tests.py -rA -v
+        run: pytest tests.py -rA -v

--- a/README.md
+++ b/README.md
@@ -433,6 +433,18 @@ Example usage:
 conan_check(VERSION 1.0.0 REQUIRED)
 ```
 
+### conan_version()
+
+Returns the Conan client version.
+
+Example usage:
+```
+conan_check(CONAN_VERSION)
+if(${CONAN_VERSION} VERSION_LESS "2.0.0")
+  ...
+endif()
+```
+
 ### conan_add_remote()
 
 Adds a remote.

--- a/conan.cmake
+++ b/conan.cmake
@@ -37,6 +37,28 @@
 
 include(CMakeParseArguments)
 
+
+function(_get_conan_version result)
+    set(${result} "" PARENT_SCOPE)
+
+    if(NOT DEFINED ${CONAN_CMD})
+        conan_check(DETECT_QUIET)
+    endif()
+
+    execute_process(COMMAND ${CONAN_CMD} --version
+                    RESULT_VARIABLE return_code
+                    OUTPUT_VARIABLE CONAN_VERSION_OUTPUT
+                    ERROR_VARIABLE CONAN_VERSION_OUTPUT)
+    if(NOT "${return_code}" STREQUAL "0")
+        message(FATAL_ERROR "Conan --version failed='${return_code}'")
+    endif()
+    
+    string(REGEX MATCH ".*Conan version ([0-9]+\\.[0-9]+\\.[0-9]+)" FOO
+      "${CONAN_VERSION_OUTPUT}")
+    set(${result} ${CMAKE_MATCH_1} PARENT_SCOPE)
+endfunction()
+
+
 function(_get_msvc_ide_version result)
     set(${result} "" PARENT_SCOPE)
     if(NOT MSVC_VERSION VERSION_LESS 1400 AND MSVC_VERSION VERSION_LESS 1500)

--- a/tests.py
+++ b/tests.py
@@ -6,6 +6,7 @@ import shutil
 import json
 import textwrap
 from contextlib import contextmanager 
+from conan import conan_version
 
 
 def save(filename, content):
@@ -1011,6 +1012,23 @@ class LocalTests(unittest.TestCase):
         with open("conan.cmake", "r") as handle:
             if "# version: " not in handle.read():
                 raise Exception("Version missing in conan.cmake")
+
+    def test_conan_version(self):
+        content = textwrap.dedent("""
+            cmake_minimum_required(VERSION 3.9)
+            project(someproject CXX)
+            include(conan.cmake)
+            conan_version(CONAN_VERSION)
+            message(STATUS "Conan Version is: ${CONAN_VERSION}")
+            """)
+        save("CMakeLists.txt", content)
+
+        os.makedirs("build")
+        os.chdir("build")
+        run("cmake .. %s -DCMAKE_BUILD_TYPE=Release > output.txt" % self.generator)
+        with open('output.txt', 'r') as file:
+            data = file.read()
+            assert f"Conan Version is: {str(conan_version.major)}.{str(conan_version.minor)}.{str(conan_version.patch)}" in data
 
     @unittest.skipIf(platform.system() != "Windows", "toolsets only in Windows")
     def test_vs_toolset(self):


### PR DESCRIPTION
Add `conan_version()` function to aquire the current Conan version.

Since some of `settings` are introduced in Conan 2.X but not in Conan 1.X or some of them are deprecated in Conan 2.X, for example when using MSVC compiler,

- In **Conan 1.X**, we may use `Visual Studio` in `compiler`.
- In **Conan 2.X**, we need to use `msvc` in `compiler`. (because `Visual Studio` is removed in `settings.yml`)

Therefore, I think `conan-cmake` needs a mechanism to determine whether it is using **Conan 1.X** or **Conan 2.X**.

The following is an example usage of `conan_version()` function.

```cmake
conan_version(CONAN_VERSION)
if(CONAN_VERSION VERSION_GREATER_EQUAL 2.0.0)
    # For Conan 2.X
else()
    # For Conan 1.X
endif()
```