### PR TITLE
fix(#467): Modify the "" in CONF of conan_cmake_profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,8 +484,8 @@ conan_cmake_profile(FILEPATH      "${CMAKE_BINARY_DIR}/profile"
                                   compiler.cppstd=14
                     OPTIONS       fmt:shared=True
                                   fmt:header_only=False
-                    CONF          tools.cmake.cmaketoolchain:generator="Visual Studio 16 2019"
-                                  tools.cmake.cmaketoolchain:toolset_arch=x64
+                    CONF          "tools.cmake.cmaketoolchain:generator=Visual Studio 16 2019"
+                                  "tools.cmake.cmaketoolchain:toolset_arch=x64"
                     TOOL_REQUIRES cmake/3.16.3)
 ```
 

--- a/tests.py
+++ b/tests.py
@@ -896,9 +896,9 @@ class CMakeConanTest(unittest.TestCase):
                               compiler.cppstd=14
                 OPTIONS       fmt:shared=True
                               fmt:header_only=False
-                CONF          tools.cmake.cmaketoolchain:generator="Visual Studio 16 2019"
-                              tools.cmake.cmaketoolchain:toolset_arch=x64
-                              tools.cmake.build:jobs=10
+                CONF          "tools.cmake.cmaketoolchain:generator=Visual Studio 16 2019"
+                              "tools.cmake.cmaketoolchain:toolset_arch=x64"
+                              "tools.cmake.build:jobs=10"
                 ENV           "MyPath1=(path)/some/path11"
                               "MyPath1=+(path)/other/path12"
                 BUILDENV      "MyPath2=(path)/some/path21"
@@ -922,7 +922,7 @@ class CMakeConanTest(unittest.TestCase):
             fmt:shared=True
             fmt:header_only=False
             [conf]
-            tools.cmake.cmaketoolchain:generator="Visual Studio 16 2019"
+            tools.cmake.cmaketoolchain:generator=Visual Studio 16 2019
             tools.cmake.cmaketoolchain:toolset_arch=x64
             tools.cmake.build:jobs=10
             [env]


### PR DESCRIPTION
Fix: #467 

Use double quotes to include the whole argument of CONF instead of a part of it.

Before:

```
tools.cmake.cmaketoolchain:generator="Visual Studio 16 2019"
```

After:

```
"tools.cmake.cmaketoolchain:generator=Visual Studio 16 2019"
```
