### PR TITLE
Add file to configure Conan as a cmake dependency  provider

### DIFF
--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -8,8 +8,7 @@ macro(conan_provide_dependency package_name)
 
     if(NOT CONAN_INSTALL_SUCCESS)
         detect_host_profile(${CMAKE_BINARY_DIR}/conan_host_profile)
-        # TODO; consider adding -g CMakeDeps to cover case where conanfile doesn't specify any
-        conan_install(-pr ${CMAKE_BINARY_DIR}/conan_host_profile --output-folder ${CONAN_OUTPUT_FOLDER})
+        conan_install(-pr ${CMAKE_BINARY_DIR}/conan_host_profile --output-folder ${CONAN_OUTPUT_FOLDER} -g CMakeDeps)
         if (CONAN_INSTALL_SUCCESS)
             message("Conan generators folder: ${CONAN_GENERATORS_FOLDER}")
             set(CONAN_GENERATORS_FOLDER "${CONAN_GENERATORS_FOLDER}" CACHE PATH "Conan generators folder")

--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.24)
+
+include("${CMAKE_CURRENT_LIST_DIR}/conantools.cmake")
+
+set(CONAN_OUTPUT_FOLDER ${CMAKE_BINARY_DIR}/conan)
+
+macro(conan_provide_dependency package_name)
+
+    if(NOT CONAN_INSTALL_SUCCESS)
+        detect_host_profile(${CMAKE_BINARY_DIR}/conan_host_profile)
+        # TODO; consider adding -g CMakeDeps to cover case where conanfile doesn't specify any
+        conan_install(-pr ${CMAKE_BINARY_DIR}/conan_host_profile --output-folder ${CONAN_OUTPUT_FOLDER})
+        if (CONAN_INSTALL_SUCCESS)
+            message("Conan generators folder: ${CONAN_GENERATORS_FOLDER}")
+            set(CONAN_GENERATORS_FOLDER "${CONAN_GENERATORS_FOLDER}" CACHE PATH "Conan generators folder")
+        endif()
+    endif()
+
+    if (CONAN_GENERATORS_FOLDER)
+        list(PREPEND CMAKE_PREFIX_PATH "${CONAN_GENERATORS_FOLDER}")
+    endif()
+
+    find_package(${ARGN} BYPASS_PROVIDER)
+endmacro()
+
+
+cmake_language(
+  SET_DEPENDENCY_PROVIDER conan_provide_dependency
+  SUPPORTED_METHODS FIND_PACKAGE
+)

--- a/conantools.cmake
+++ b/conantools.cmake
@@ -15,6 +15,9 @@ endfunction()
 
 function(detect_cxx_standard CXX_STANDARD)
     set(CXX_STANDARD ${CMAKE_CXX_STANDARD} PARENT_SCOPE)
+    if (CMAKE_CXX_EXTENSIONS)
+        set(CXX_STANDARD "gnu${CMAKE_CXX_STANDARD}" PARENT_SCOPE)
+    endif()
 endfunction()
 
 
@@ -33,9 +36,13 @@ function(detect_compiler COMPILER COMPILER_VERSION)
     message(STATUS "Conan-cmake: CMake compiler=${COMPILER}") 
     message(STATUS "Conan-cmake: CMake cmpiler version=${COMPILER_VERSION}")
 
-    if(${COMPILER} EQUAL MSVC)
+    if(COMPILER MATCHES MSVC)
         set(COMPILER "msvc")
         string(SUBSTRING ${MSVC_VERSION} 0 3 COMPILER_VERSION)
+    elseif(COMPILER MATCHES AppleClang)
+        set(COMPILER "apple-clang")
+        string(REPLACE "." ";" VERSION_LIST ${CMAKE_CXX_COMPILER_VERSION})
+        list(GET VERSION_LIST 0 COMPILER_VERSION)
     endif()
 
     message(STATUS "Conan-cmake: [settings] compiler=${COMPILER}") 
@@ -45,11 +52,20 @@ function(detect_compiler COMPILER COMPILER_VERSION)
     set(COMPILER_VERSION ${COMPILER_VERSION} PARENT_SCOPE)
 endfunction()
 
+function(detect_build_type)
+    if(NOT CMAKE_CONFIGURATION_TYPES)
+        # Only set when we know we are in a single-configuration generator
+        # Note: we may want to fail early if `CMAKE_BUILD_TYPE` is not defined
+        set(BUILD_TYPE ${CMAKE_BUILD_TYPE} PARENT_SCOPE)
+    endif()
+endfunction()
 
-function(detect_host_profile)
+
+function(detect_host_profile output_file)
     detect_os(OS)
     detect_compiler(COMPILER COMPILER_VERSION)
     detect_cxx_standard(CXX_STANDARD)
+    detect_build_type()
 
     set(PROFILE "")
     string(APPEND PROFILE "include(default)\n")
@@ -66,8 +82,15 @@ function(detect_host_profile)
     if(CXX_STANDARD)
         string(APPEND PROFILE compiler.cppstd=${CXX_STANDARD} "\n")
     endif()
+    if(BUILD_TYPE)
+        string(APPEND PROFILE "build_type=${BUILD_TYPE}\n")
+    endif()
 
-    set(_FN "${CMAKE_BINARY_DIR}/profile")
+    if(NOT DEFINED output_file)
+        set(_FN "${CMAKE_BINARY_DIR}/profile")
+    else()
+        set(_FN ${output_file})
+    endif()
     message(STATUS "Conan-cmake: Creating profile ${_FN}")
     file(WRITE ${_FN} ${PROFILE})
     message(STATUS "Conan-cmake: Profile: \n${PROFILE}")
@@ -77,11 +100,27 @@ endfunction()
 function(conan_install)
     cmake_parse_arguments(ARGS CONAN_ARGS ${ARGN})
     # Invoke "conan install" with the provided arguments
-    message(STATUS "conan install ${CMAKE_CURRENT_SOURCE_DIR} ${CONAN_ARGS}")
-    execute_process(COMMAND conan install ${CMAKE_CURRENT_SOURCE_DIR} ${CONAN_ARGS}
+    message(STATUS "conan install ${CMAKE_SOURCE_DIR} ${CONAN_ARGS}")
+    execute_process(COMMAND conan install ${CMAKE_SOURCE_DIR} ${CONAN_ARGS}  --format=json
                     RESULT_VARIABLE return_code
+                    OUTPUT_VARIABLE conan_stdout
+                    ERROR_VARIABLE conan_stderr
+                    ECHO_ERROR_VARIABLE    # show the text output regardless
                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     if(NOT "${return_code}" STREQUAL "0")
         message(FATAL_ERROR "Conan install failed='${return_code}'")
+        string()
+    else()
+        # the files are generated in a folder that depends on the layout used, if
+        # one if specified, but we don't know a priori where this is. 
+        # TODO: this can be made more robust if Conan can provide this in the json output
+        string(JSON conan_build_folder GET ${conan_stdout} graph nodes 0 build_folder)
+        # message("conan stdout: ${conan_stdout}")
+        message("conan build folder: ${conan_build_folder}")
+        file(GLOB_RECURSE conanrun_files LIST_DIRECTORIES false "conanrun*")
+        list(GET conanrun_files 0 conanrun)
+        get_filename_component(CONAN_GENERATORS_FOLDER ${conanrun} DIRECTORY)
+        set(CONAN_GENERATORS_FOLDER "${CONAN_GENERATORS_FOLDER}" PARENT_SCOPE)
+        set(CONAN_INSTALL_SUCCESS TRUE CACHE BOOL "Conan install has been invoked and was successful")
     endif()
 endfunction()

--- a/conantools.cmake
+++ b/conantools.cmake
@@ -100,8 +100,8 @@ endfunction()
 function(conan_install)
     cmake_parse_arguments(ARGS CONAN_ARGS ${ARGN})
     # Invoke "conan install" with the provided arguments
-    message(STATUS "conan install ${CMAKE_SOURCE_DIR} ${CONAN_ARGS}")
-    execute_process(COMMAND conan install ${CMAKE_SOURCE_DIR} ${CONAN_ARGS}  --format=json
+    message(STATUS "conan install ${CMAKE_SOURCE_DIR} ${CONAN_ARGS} ${ARGN}")
+    execute_process(COMMAND conan install ${CMAKE_SOURCE_DIR} ${CONAN_ARGS} ${ARGN} --format=json
                     RESULT_VARIABLE return_code
                     OUTPUT_VARIABLE conan_stdout
                     ERROR_VARIABLE conan_stderr

--- a/tests_new.py
+++ b/tests_new.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import shutil
 import tempfile
 import textwrap
@@ -60,7 +61,7 @@ def test1():
         cmake_minimum_required(VERSION 3.15)
         project(MyApp CXX)
 
-        find_package(hello)
+        find_package(hello REQUIRED)
         add_executable(app main.cpp)
         target_link_libraries(app hello::hello)
         """)
@@ -81,11 +82,15 @@ def test1():
     save("conanfile.txt", conanfile)
     save("CMakeLists.txt", cmake)
     save("user.cmake", "set(CMAKE_CXX_STANDARD 17)")
+    shutil.copy2(os.path.join(os.path.dirname(__file__), "conan_provider.cmake"), ".")
     shutil.copy2(os.path.join(os.path.dirname(__file__), "conaninstall.cmake"), ".")
     shutil.copy2(os.path.join(os.path.dirname(__file__), "conantools.cmake"), ".")
     with chdir("build"):
-        run("cmake .. -DCMAKE_PROJECT_INCLUDE=conaninstall.cmake -DCMAKE_TOOLCHAIN_FILE=user.cmake")
+        run("cmake .. -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=conan_provider.cmake -DCMAKE_TOOLCHAIN_FILE=user.cmake -DCMAKE_BUILD_TYPE=Release")
         run("cmake --build . --config Release")
-        run(r"Release\app.exe")
+        if platform.system() == "Windows":
+            run(r"Release\app.exe")
+        else:
+            run("./app")
 
 


### PR DESCRIPTION
* Add `conan_provider.cmake` with logic to call CMake's `SET_DEPENDENCY_PROVIDER`  - note that we could reuse `conaninstall.cmake` and do it there directly.
* Amend tests to pass `conan_provider.cmake` via `CMAKE_PROJECT_TOP_LEVEL_INCLUDES`
* Add logic to handle CMake -> conan compiler name for Apple Clang
* Add logic to handle figuring out where the generated files end up at (since this depends on the layout defined, if one is defined)
* Add logic to persist that directory across CMake runs (as conan is only invoked once).
