### PR TITLE
Bugfix: dependency provider must be a macro

### DIFF
--- a/conan_support.cmake
+++ b/conan_support.cmake
@@ -158,7 +158,7 @@ function(conan_install)
 endfunction()
 
 
-function(conan_provide_dependency package_name)
+macro(conan_provide_dependency package_name)
     if(NOT CONAN_INSTALL_SUCCESS)
         message(STATUS "CMake-conan: first find_package() found. Installing dependencies with Conan")
         conan_profile_detect_default()
@@ -175,12 +175,11 @@ function(conan_provide_dependency package_name)
             set(CONAN_GENERATORS_FOLDER "${CONAN_GENERATORS_FOLDER}" CACHE PATH "Conan generators folder")
         endif()
     else()
-        message(STATUS "CMake-conan: find_package(${package_name}) found, 'conan install' aready ran")
+        message(STATUS "CMake-conan: find_package(${ARGV1}) found, 'conan install' aready ran")
     endif()
 
     if (CONAN_GENERATORS_FOLDER)
         list(PREPEND CMAKE_PREFIX_PATH "${CONAN_GENERATORS_FOLDER}")
     endif()
-
     find_package(${ARGN} BYPASS_PROVIDER)
-endfunction()
+endmacro()


### PR DESCRIPTION
Fix issue where the the `xxx-config.cmake` in the generator folders files were being processed twice because the `xx_FOUND` variable was not being exposed to be parent expose.

The CMake [documentation](https://cmake.org/cmake/help/latest/command/cmake_language.html#dependency-providers) states that the dependency provider must be a _macro_:

> `xxx_provide_dependency(<method> [<method-specific-args>...])`
> Because some methods expect certain variables to be set in the calling scope, the provider command should typically be implemented as a macro rather than a function. This ensures it does not introduce a new variable scope.

This was causing the `xxx_FOUND` variable coming from calling CMake's own `find_package` (with `BYPASS_PROVIDER`) to not be exposed, which was causing the file to be processed twice for a single call to `find_package` (from the consumer side). It's still unusual/explained that the file was processed twice, but making the dependency provider a macro fixes the issue correctly, and will avoid other issues in the future (anything that is `SET` inside the config files may otherwise not be correctly exposed to the parent scope).


Fixes https://github.com/conan-io/cmake-conan/issues/489

As a side note, the files generated by CMakeDeps should not print warnings if the target was already generated - it should be perfectly safe (and it currently is) for the file to be processed twice - there's nothing to warn about as it is already behaving correctly by not defining the target twice.
