### PR TITLE
Use presets to simplify configuration and build commands

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,20 @@
+{
+  "version": 5,
+  "configurePresets":[
+    {
+      "name": "default",
+      "binaryDir": "build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_PROJECT_TOP_LEVEL_INCLUDES": "conan_provider.cmake"
+      }
+    }
+  ],
+  "buildPresets":[
+    {
+      "name": "default",
+      "configurePreset": "default",
+      "configuration": "Release"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -26,9 +26,8 @@ This repository contains a `CMakeLists.txt` with an example project that depends
 
 ```bash
 cd cmake-conan
-mkdir build
-cmake -B build -S . -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=conan_provider.cmake -DCMAKE_BUILD_TYPE=Release
-cmake --build build --config Release
+cmake --preset default
+cmake --build --preset default
 ```
 
 ### In your own project

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ cmake --build --preset default
 
 ```bash
 cd [your-project]
-mkdir build
 cmake -B build -S . -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=[path-to-cmake-conan]/conan_provider.cmake -DCMAKE_BUILD_TYPE=Release
 ```
 


### PR DESCRIPTION
CMake presets are the perfect tool to capture the particular flags required to build the `develop2` branch. This repo ought to set an example for how presets can be used to avoid typing out long configuration commands.
