### PR TITLE
feat: reconfigure on conanfile changes

### DIFF
--- a/.github/workflows/cmake_conan.yml
+++ b/.github/workflows/cmake_conan.yml
@@ -22,4 +22,4 @@ jobs:
         with:
           cmake-version: '3.25.x'
       - name: Run Tests
-        run: pytest tests.py -rA -v
+        run: pytest -rA -v

--- a/README.md
+++ b/README.md
@@ -55,5 +55,5 @@ cmake -B build -S . -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=[path-to-cmake-conan]/con
 There are some tests, you can run in python, with pytest, for example:
 
 ```bash
-$ pytest tests.py -rA
+$ pytest -rA
 ```


### PR DESCRIPTION
This will reconfigure on changes in the conanfile and also move the conan install success to a global property instead of a cache variable.