### PR TITLE
develop2: test single and multi configuration CMake generators on all platforms

### DIFF
--- a/.github/workflows/cmake_conan.yml
+++ b/.github/workflows/cmake_conan.yml
@@ -11,6 +11,11 @@ jobs:
           - os: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.2
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64
+        if: ${{ matrix.os == 'windows-2019' }}
+        name: setup msvc vcvars
       - name: Setup Python
         uses: actions/setup-python@v4.6.0
         with:


### PR DESCRIPTION
Precursor PR so that we can add tests on Windows to cover multiple `CMAKE_MSVC_RUNTIME_LIBRARY` scenarios.

Changes in this PR:
* Refactor use of `rm -rf *`  to `shutil.rmtree()`, since the former is _not_ a command on typical Windows shells (cmd or powershell) - I was getting errors running this on a local Windows development environment. 
* Refactor  tests such that single and multi configuration are tested on both platforms - the differences are in what generator is passed to CMake:
    * Single config, Windows: `Ninja`
    * Single config, macOS/Linux: empty (would be Makefiles)
    * Multi config, Windows: empty (would be Visual Studio)
    * Multi config, macOS/Linux: `Ninja Multi-Config`
* Condense tests - there are now two where there were 3 before, covering the same functionality 
* Refactor to avoid repeated code for identical logic
* On Windows, initialize vcvars via `ilammy/msvc-dev-cmd@v1` github actions integration, otherwise CMake does not find the correct compiler on Windows with single configuration
