### PR TITLE
feat: set tool path

### DIFF
--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -210,6 +210,30 @@ function(conan_install)
         # success
         set_property(GLOBAL PROPERTY CONAN_INSTALL_SUCCESS TRUE)
     endif()
+
+    # set tool path
+    set(CONAN_TOOL_PATH)
+    string(JSON NUMBER_OF_NODES LENGTH ${conan_stdout} graph nodes)
+    math(EXPR NUMBER_OF_NODES "${NUMBER_OF_NODES}-1")
+    foreach(INDEX RANGE ${NUMBER_OF_NODES})
+        string(JSON CONTEXT GET ${conan_stdout} graph nodes ${INDEX} context)
+        if(NOT CONTEXT STREQUAL "build")
+            continue()
+        endif()
+
+        string(JSON BINDIRS GET ${conan_stdout} graph nodes ${INDEX} cpp_info root bindirs)
+        string(JSON BINDIRS_NODES LENGTH ${BINDIRS})
+        if(BINDIRS_NODES EQUAL 0)
+            continue()
+        endif()
+        math(EXPR BINDIRS_NODES "${BINDIRS_NODES}-1")
+        foreach(BINDIRS_INDEX RANGE ${BINDIRS_NODES})
+            string(JSON BINDIR GET ${BINDIRS} ${BINDIRS_INDEX})
+            list(APPEND CONAN_TOOL_PATH "${BINDIR}")
+        endforeach()
+    endforeach()
+    set(CONAN_TOOL_PATH ${CONAN_TOOL_PATH} CACHE STRING "Path to build tools")
+    message(STATUS "CMake-Conan: CONAN_TOOL_PATH=${CONAN_TOOL_PATH}")
 endfunction()
 
 

--- a/tests/resources/tool/CMakeLists.txt
+++ b/tests/resources/tool/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.24)
+project(MyToolApp CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+find_package(hello REQUIRED)
+find_program(
+  NINJA_EXECUTABLE ninja
+  PATHS ${CONAN_TOOL_PATH} REQUIRED
+  NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)

--- a/tests/resources/tool/conanfile.txt
+++ b/tests/resources/tool/conanfile.txt
@@ -1,0 +1,5 @@
+[requires]
+hello/0.1
+
+[tool_requires]
+ninja/1.11.1

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,4 +1,5 @@
 import os
+import re
 import platform
 import shutil
 import subprocess
@@ -132,6 +133,26 @@ class TestBasic:
         run("cmake --build .")
         out, _ = capfd.readouterr()
         assert all(expected in out for expected in expected_conan_install_outputs)
+
+
+class TestTool:
+    @pytest.fixture(scope="class", autouse=True)
+    def tool_setup(self):
+        "Layout for tool test"
+        src_dir = Path(__file__).parent.parent
+        shutil.copytree(src_dir / 'tests' / 'resources' / 'tool', ".", dirs_exist_ok=True)
+        yield
+
+    @unix
+    def test_tool_path(self, capfd, chdir_build):
+        "Tools are available in CMake"
+        generator = "-GNinja" if platform.system() == "Windows" else ""
+
+        run(f"cmake --fresh .. -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=conan_provider.cmake -DCMAKE_BUILD_TYPE=Release {generator}")
+        out, _ = capfd.readouterr()
+        regex = re.compile(r".*--CMake-Conan:CONAN_TOOL_PATH=\/.*\/bin.*")
+        out_without_whitespace = "".join(out.split())
+        assert regex.match(out_without_whitespace)
 
 
 class TestSubdir:


### PR DESCRIPTION
Scenario: I want to install build requirements with conan. In order to use them in my CMake files after the first find_package, I have to get the conan install path into CMake context.