### PR TITLE
Add HCOS to list of supported platforms

### DIFF
--- a/conan.cmake
+++ b/conan.cmake
@@ -96,7 +96,7 @@ macro(_conan_check_system_name)
         if(${CMAKE_SYSTEM_NAME} STREQUAL "QNX")
             set(CONAN_SYSTEM_NAME Neutrino)
         endif()
-        set(CONAN_SUPPORTED_PLATFORMS Windows Linux Macos Android iOS FreeBSD WindowsStore WindowsCE watchOS tvOS FreeBSD SunOS AIX Arduino Emscripten Neutrino)
+        set(CONAN_SUPPORTED_PLATFORMS Windows Linux Macos Android iOS FreeBSD WindowsStore WindowsCE watchOS tvOS FreeBSD SunOS AIX Arduino Emscripten Neutrino HCOS)
         list (FIND CONAN_SUPPORTED_PLATFORMS "${CONAN_SYSTEM_NAME}" _index)
         if (${_index} GREATER -1)
             #check if the cmake system is a conan supported one


### PR DESCRIPTION
Hello,
I have been using conan and cmake to manage my builds and dependencies for projects targeting HCOS (honeycomb OS). I would like to add this name to the list of supported platforms.