### PR TITLE
Ensure that Find<PackageName>.cmake modules work

### DIFF
--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -275,7 +275,8 @@ macro(conan_provide_dependency package_name)
     if(${index} EQUAL -1)
         list(PREPEND CMAKE_PREFIX_PATH "${CONAN_GENERATORS_FOLDER}")
     endif()
-    find_package(${ARGN} BYPASS_PROVIDER CMAKE_FIND_ROOT_PATH_BOTH)
+    set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)
+    find_package(${ARGN} BYPASS_PROVIDER)
 endmacro()
 
 

--- a/tests/resources/cmake_module/CMakeLists.txt
+++ b/tests/resources/cmake_module/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.24)
+project(MyApp CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+find_package(Threads REQUIRED)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -134,6 +134,20 @@ class TestBasic:
         assert all(expected in out for expected in expected_conan_install_outputs)
 
 
+class TestCmakeModule:
+    @pytest.fixture(scope="class", autouse=True)
+    def cmake_module_setup(self):
+        src_dir = Path(__file__).parent.parent
+        shutil.copytree(src_dir / 'tests' / 'resources' / 'cmake_module', ".", dirs_exist_ok=True)
+        yield
+
+    def test_cmake_module(self, capfd, chdir_build):
+        "Ensure that the Find<PackageName>.cmake modules from the CMake install work"
+        run("cmake .. -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=conan_provider.cmake -DCMAKE_BUILD_TYPE=Release")
+        out, _ = capfd.readouterr()
+        assert "Found Threads: TRUE" in out
+
+
 class TestSubdir:
     @pytest.fixture(scope="class", autouse=True)
     def subdir_setup(self):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -177,7 +177,8 @@ class TestOsVersion:
 class TestAndroid:
     @pytest.fixture(scope="class", autouse=True)
     def android_setup(self):
-        shutil.rmtree("build")
+        if os.path.exists("build"):
+            shutil.rmtree("build")
         yield
 
     def test_android_armv8(self, capfd, chdir_build):


### PR DESCRIPTION
This addresses https://github.com/conan-io/cmake-conan/issues/532.

In the process of supporting `find_package()` for cross-compile scenarios, we accidentally excluded `Find<PackageName>.cmake` modules from the search. According to [CMake docs](https://cmake.org/cmake/help/latest/command/find_package.html#search-modes), only 'module mode' will look for these files, which is only available in the basic command signature of `find_package()`. By using `CMAKE_FIND_ROOT_PATH_BOTH` in `find_package()` we switched to the full command signature.

The fix does set `CMAKE_FIND_ROOT_PATH_MODE_PACKAGE` globally like it did before this [pull request comment](https://github.com/conan-io/cmake-conan/pull/521#discussion_r1226940907). I suppose I could save the value of the variable and put it back to avoid a global influence, if you want.

I added test coverage for this scenario. While investigating, I realized the Android tests were failing if the build folder wasn't already there, making it impossible to run `pytest -k android` so I fixed that too!