### PR TITLE
Handle warning when the dependency provider is set but not used

### DIFF
--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -359,15 +359,18 @@ macro(conan_provide_dependency_check)
     set(_CONAN_PROVIDE_DEPENDENCY_INVOKED FALSE)
     get_property(_CONAN_PROVIDE_DEPENDENCY_INVOKED GLOBAL PROPERTY CONAN_PROVIDE_DEPENDENCY_INVOKED)
     if(NOT _CONAN_PROVIDE_DEPENDENCY_INVOKED)
-        message(WARNING "Conan configured as dependency provider, but never invoked. There are no calls to `find_package()`")
+        message(WARNING "Conan is correctly configured as dependency provider, "
+                        "but Conan has not been invoked. Please add at least one "
+                        "call to `find_package()`.")
         if(DEFINED CONAN_COMMAND)
-            set(_CONAN_COMMAND ${CONAN_COMMAND})
             # supress warning in case `CONAN_COMMAND` was specified but unused.
+            set(_CONAN_COMMAND ${CONAN_COMMAND})
+            unset(_CONAN_COMMAND)
         endif()
-
     endif()
     unset(_CONAN_PROVIDE_DEPENDENCY_INVOKED)
-    unset(_CONAN_COMMAND)
 endmacro()
 
+# Add a deferred call at the end of processing the top-level directory
+# to check if the dependency provider was invoked at all.
 cmake_language(DEFER DIRECTORY "${CMAKE_SOURCE_DIR}" CALL conan_provide_dependency_check)

--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -300,6 +300,7 @@ endfunction()
 
 
 macro(conan_provide_dependency method package_name)
+    set_property(GLOBAL PROPERTY CONAN_PROVIDE_DEPENDENCY_INVOKED TRUE)
     get_property(CONAN_INSTALL_SUCCESS GLOBAL PROPERTY CONAN_INSTALL_SUCCESS)
     if(NOT CONAN_INSTALL_SUCCESS)
         find_program(CONAN_COMMAND "conan" REQUIRED)
@@ -353,3 +354,20 @@ cmake_language(
   SET_DEPENDENCY_PROVIDER conan_provide_dependency
   SUPPORTED_METHODS FIND_PACKAGE
 )
+
+macro(conan_provide_dependency_check)
+    set(_CONAN_PROVIDE_DEPENDENCY_INVOKED FALSE)
+    get_property(_CONAN_PROVIDE_DEPENDENCY_INVOKED GLOBAL PROPERTY CONAN_PROVIDE_DEPENDENCY_INVOKED)
+    if(NOT _CONAN_PROVIDE_DEPENDENCY_INVOKED)
+        message(WARNING "Conan configured as dependency provider, but never invoked. There are no calls to `find_package()`")
+        if(DEFINED CONAN_COMMAND)
+            set(_CONAN_COMMAND ${CONAN_COMMAND})
+            # supress warning in case `CONAN_COMMAND` was specified but unused.
+        endif()
+
+    endif()
+    unset(_CONAN_PROVIDE_DEPENDENCY_INVOKED)
+    unset(_CONAN_COMMAND)
+endmacro()
+
+cmake_language(DEFER DIRECTORY "${CMAKE_SOURCE_DIR}" CALL conan_provide_dependency_check)


### PR DESCRIPTION
If a consumer passes both `-DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=conan_provider.cmake` and `-DCONAN_COMMAND=/path/to/bin/conan`, but the project makes no calls to `find_package()`, user will see this warning:
```
CMake Warning:
  Manually-specified variables were not used by the project:

    CONAN_COMMAND
```


This PR makes use of the `DEFER` `cmake_language()` feature such that if at the end processing the top-level `CMakeLists.txt` the dependency provider was not invoked at least once, it displays a more meaningful warning, while at the same time it suppresses the unused variable warning:

```
CMake Warning at conan_provider.cmake:362 (message):
  Conan is correctly configured as dependency provider, but Conan has not
  been invoked.  Please add at least one call to `find_package()`.
Call Stack (most recent call first):
  conan_provider.cmake:376 (conan_provide_dependency_check)
  CMakeLists.txt:DEFERRED
```

