### PR TITLE
Added [buildenv] Field Generation

### DIFF
--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -203,6 +203,11 @@ function(detect_host_profile output_file)
         string(APPEND PROFILE "tools.android:ndk_path=${CMAKE_ANDROID_NDK}\n")
     endif()
 
+    string(APPEND PROFILE "[buildenv]\n")
+    string(APPEND PROFILE "CC=${CMAKE_C_COMPILER}\n")
+    string(APPEND PROFILE "CXX=${CMAKE_CXX_COMPILER}\n")
+    string(APPEND PROFILE "LD=${CMAKE_LINKER}\n")
+
     message(STATUS "CMake-Conan: Creating profile ${_FN}")
     file(WRITE ${_FN} ${PROFILE})
     message(STATUS "CMake-Conan: Profile: \n${PROFILE}")


### PR DESCRIPTION
Modified the `detect_host_profile` function in `conan_provider.cmake` to support the generation of the [buildenv] field. This enhancement allows for a closer integration with the compilers configured in CMake, thereby improving usability for cross-compilation and cross-platform scenarios.