### PR TITLE
Propagate compiler executable via profile configuration

### DIFF
--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -247,6 +247,25 @@ function(detect_host_profile output_file)
 
     string(APPEND PROFILE "[conf]\n")
     string(APPEND PROFILE "tools.cmake.cmaketoolchain:generator=${CMAKE_GENERATOR}\n")
+
+    # propagate compilers via profile
+    set(_conan_c_compiler "")
+    set(_conan_cpp_compiler "")
+    if(CMAKE_C_COMPILER)
+        set(_conan_c_compiler "\"c\":\"${CMAKE_C_COMPILER}\",")
+    else()
+        message(WARNING "CMake-Conan: The C compiler is not defined. "
+                        "Please define CMAKE_C_COMPILER or enable the C language.")
+    endif()
+    if(CMAKE_CXX_COMPILER)
+        set(_conan_cpp_compiler "\"cpp\":\"${CMAKE_CXX_COMPILER}\"")
+    else()
+        message(WARNING "CMake-Conan: The C++ compiler is not defined. "
+                        "Please define CMAKE_CXX_COMPILER or enable the C++ language.")
+    endif()
+
+    string(APPEND PROFILE "tools.build:compiler_executables={${_conan_c_compiler}${_conan_cpp_compiler}}\n")
+
     if(${MYOS} STREQUAL "Android")
         string(APPEND PROFILE "tools.android:ndk_path=${CMAKE_ANDROID_NDK}\n")
     endif()

--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -187,6 +187,27 @@ function(detect_build_type BUILD_TYPE)
     endif()
 endfunction()
 
+macro(append_compiler_executables_configuration)
+    set(_conan_c_compiler "")
+    set(_conan_cpp_compiler "")
+    if(CMAKE_C_COMPILER)
+        set(_conan_c_compiler "\"c\":\"${CMAKE_C_COMPILER}\",")
+    else()
+        message(WARNING "CMake-Conan: The C compiler is not defined. "
+                        "Please define CMAKE_C_COMPILER or enable the C language.")
+    endif()
+    if(CMAKE_CXX_COMPILER)
+        set(_conan_cpp_compiler "\"cpp\":\"${CMAKE_CXX_COMPILER}\"")
+    else()
+        message(WARNING "CMake-Conan: The C++ compiler is not defined. "
+                        "Please define CMAKE_CXX_COMPILER or enable the C++ language.")
+    endif()
+
+    string(APPEND PROFILE "tools.build:compiler_executables={${_conan_c_compiler}${_conan_cpp_compiler}}\n")
+    unset(_conan_c_compiler)
+    unset(_conan_cpp_compiler)
+endmacro()
+
 
 function(detect_host_profile output_file)
     detect_os(MYOS MYOS_API_LEVEL MYOS_SDK MYOS_SUBSYSTEM MYOS_VERSION)
@@ -249,22 +270,7 @@ function(detect_host_profile output_file)
     string(APPEND PROFILE "tools.cmake.cmaketoolchain:generator=${CMAKE_GENERATOR}\n")
 
     # propagate compilers via profile
-    set(_conan_c_compiler "")
-    set(_conan_cpp_compiler "")
-    if(CMAKE_C_COMPILER)
-        set(_conan_c_compiler "\"c\":\"${CMAKE_C_COMPILER}\",")
-    else()
-        message(WARNING "CMake-Conan: The C compiler is not defined. "
-                        "Please define CMAKE_C_COMPILER or enable the C language.")
-    endif()
-    if(CMAKE_CXX_COMPILER)
-        set(_conan_cpp_compiler "\"cpp\":\"${CMAKE_CXX_COMPILER}\"")
-    else()
-        message(WARNING "CMake-Conan: The C++ compiler is not defined. "
-                        "Please define CMAKE_CXX_COMPILER or enable the C++ language.")
-    endif()
-
-    string(APPEND PROFILE "tools.build:compiler_executables={${_conan_c_compiler}${_conan_cpp_compiler}}\n")
+    append_compiler_executables_configuration()
 
     if(${MYOS} STREQUAL "Android")
         string(APPEND PROFILE "tools.android:ndk_path=${CMAKE_ANDROID_NDK}\n")

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -264,27 +264,27 @@ class TestGeneratedProfile:
     @linux
     def test_propagate_cxx_compiler(self, capfd, chdir_build):
         """Test that the C++ compiler is propagated via tools.build:compiler_executables"""
-        run(f"cmake .. -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=conan_provider.cmake -DCMAKE_BUILD_TYPE=Release", check=True)
+        run(f"cmake --fresh .. -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=conan_provider.cmake -DCMAKE_BUILD_TYPE=Release", check=True)
         out, err = capfd.readouterr()
-        assert "The CXX compiler identification is GNU" in err
+        assert "The CXX compiler identification is GNU" in out
         assert "CMake-Conan: The C compiler is not defined." in err
         assert 'tools.build:compiler_executables={"cpp":"/usr/bin/c++"}' in out
 
     @linux
     def test_propagate_c_compiler(self, capfd, chdir_build):
         """Test that the C compiler is propagated when defined, even if the project only enables C++"""
-        run(f"cmake .. -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=conan_provider.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/bin/cc", check=True)
+        run(f"cmake --fresh .. -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=conan_provider.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/bin/cc", check=True)
         out, err = capfd.readouterr()
-        assert "The CXX compiler identification is GNU" in err
+        assert "The CXX compiler identification is GNU" in out
         assert "The C compiler is not defined." not in err
         assert 'tools.build:compiler_executables={"c":"/usr/bin/cc","cpp":"/usr/bin/c++"}' in out
 
     @linux
     def test_propagate_non_default_compiler(self, capfd, chdir_build):
         """Test that the C++ compiler is propagated via tools.build:compiler_executables"""
-        run(f"cmake .. -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=conan_provider.cmake -DCMAKE_BUILD_TYPE=Release", check=True)
+        run(f"cmake --fresh .. -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=conan_provider.cmake -DCMAKE_BUILD_TYPE=Release", check=True)
         out, err = capfd.readouterr()
-        assert "The CXX compiler identification is Clang" in err
+        assert "The CXX compiler identification is Clang" in out
         assert "The C compiler is not defined." not in err
         assert 'tools.build:compiler_executables={"c":"/usr/bin/clang","cpp":"/usr/bin/clang++"}' in out
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -266,7 +266,7 @@ class TestGeneratedProfile:
         """Test that the C++ compiler is propagated via tools.build:compiler_executables"""
         run(f"cmake .. -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=conan_provider.cmake -DCMAKE_BUILD_TYPE=Release", check=True)
         out, err = capfd.readouterr()
-        assert "The CXX compiler identification is GNU" in out
+        assert "The CXX compiler identification is GNU" in err
         assert "CMake-Conan: The C compiler is not defined." in err
         assert 'tools.build:compiler_executables={"cpp":"/usr/bin/c++"}' in out
 
@@ -275,16 +275,16 @@ class TestGeneratedProfile:
         """Test that the C compiler is propagated when defined, even if the project only enables C++"""
         run(f"cmake .. -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=conan_provider.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/bin/cc", check=True)
         out, err = capfd.readouterr()
-        assert "The CXX compiler identification is GNU" in out
+        assert "The CXX compiler identification is GNU" in err
         assert "The C compiler is not defined." not in err
         assert 'tools.build:compiler_executables={"c":"/usr/bin/cc","cpp":"/usr/bin/c++"}' in out
 
     @linux
     def test_propagate_non_default_compiler(self, capfd, chdir_build):
         """Test that the C++ compiler is propagated via tools.build:compiler_executables"""
-        run(f"cmake .. -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=conan_provider.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++", check=True)
+        run(f"cmake .. -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=conan_provider.cmake -DCMAKE_BUILD_TYPE=Release", check=True)
         out, err = capfd.readouterr()
-        assert "The CXX compiler identification is Clang" in out
+        assert "The CXX compiler identification is Clang" in err
         assert "The C compiler is not defined." not in err
         assert 'tools.build:compiler_executables={"c":"/usr/bin/clang","cpp":"/usr/bin/clang++"}' in out
 


### PR DESCRIPTION
Propagate the compiler executables via the `tools.build:compiler_executable` Conan configuration in the generated profile.

This is particularly necessary when the compiler the CMake build is configured with is _anything other than_ what CMake would auto-detect. This fixes an issue where if not propagated, when building dependencies from source (due to `--build=missing`), Conan might pass flags that are Clang-only, when CMake detects the system default (likely to be gcc).

