### PR TITLE
#578 Convert backslash characters in CONAN_GENERATORS_FOLDER to avoid escaping on Windows

### DIFF
--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -386,6 +386,7 @@ function(conan_install)
         # one is specified, but we don't know a priori where this is.
         # TODO: this can be made more robust if Conan can provide this in the json output
         string(JSON CONAN_GENERATORS_FOLDER GET ${conan_stdout} graph nodes 0 generators_folder)
+        cmake_path(CONVERT ${CONAN_GENERATORS_FOLDER} TO_CMAKE_PATH_LIST CONAN_GENERATORS_FOLDER)
         # message("conan stdout: ${conan_stdout}")
         message(STATUS "CMake-Conan: CONAN_GENERATORS_FOLDER=${CONAN_GENERATORS_FOLDER}")
         set_property(GLOBAL PROPERTY CONAN_GENERATORS_FOLDER "${CONAN_GENERATORS_FOLDER}")


### PR DESCRIPTION
A fix for the issue: https://github.com/conan-io/cmake-conan/issues/578