### PR TITLE
Add support for CMake version less than 3.24

### DIFF
--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -1,5 +1,6 @@
 set(CONAN_MINIMUM_VERSION 2.0.5)
 
+
 function(detect_os OS OS_API_LEVEL OS_SDK OS_SUBSYSTEM OS_VERSION)
     # it could be cross compilation
     message(STATUS "CMake-Conan: cmake_system_name=${CMAKE_SYSTEM_NAME}")

--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -576,7 +576,7 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
     )
 else()
     macro(find_package)
-        conan_provide_dependency(${ARGV})
+        conan_provide_dependency(FIND_PACKAGE ${ARGV})
     endmacro()
 endif()
 

--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -574,6 +574,10 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
         SET_DEPENDENCY_PROVIDER conan_provide_dependency
         SUPPORTED_METHODS FIND_PACKAGE
     )
+else()
+    macro(find_package)
+        conan_provide_dependency(${ARGV})
+    endmacro()
 endif()
 
 

--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -1,6 +1,5 @@
 set(CONAN_MINIMUM_VERSION 2.0.5)
 
-
 function(detect_os OS OS_API_LEVEL OS_SDK OS_SUBSYSTEM OS_VERSION)
     # it could be cross compilation
     message(STATUS "CMake-Conan: cmake_system_name=${CMAKE_SYSTEM_NAME}")
@@ -545,7 +544,12 @@ macro(conan_provide_dependency method package_name)
     set(_find_args_${package_name} "${ARGN}")
     list(REMOVE_ITEM _find_args_${package_name} "REQUIRED")
     if(NOT "MODULE" IN_LIST _find_args_${package_name})
-        find_package(${package_name} ${_find_args_${package_name}} BYPASS_PROVIDER PATHS "${_conan_generators_folder}" NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+        if (CMAKE_VERSION VERSION_LESS "3.24")
+            # use undocumended cmake function
+            _find_package(${package_name} ${_find_args_${package_name}} PATHS "${_conan_generators_folder}" NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+        else()
+            find_package(${package_name} ${_find_args_${package_name}} BYPASS_PROVIDER PATHS "${_conan_generators_folder}" NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+        endif()
         unset(_find_args_${package_name})
     endif()
 
@@ -564,10 +568,12 @@ macro(conan_provide_dependency method package_name)
 endmacro()
 
 
-cmake_language(
-    SET_DEPENDENCY_PROVIDER conan_provide_dependency
-    SUPPORTED_METHODS FIND_PACKAGE
-)
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
+    cmake_language(
+        SET_DEPENDENCY_PROVIDER conan_provide_dependency
+        SUPPORTED_METHODS FIND_PACKAGE
+    )
+endif()
 
 
 macro(conan_provide_dependency_check)


### PR DESCRIPTION
Allow to use `conan_provider.cmake` with older versions of cmake.
Uses undocumented function `_find_package` to override `find_package` function with `conan_provide_dependency`.

The same method can be used to override `find_program`, `find_library`, `find_path` or `find_file` - by defining macro/function which name matches buildin command cmake creates `_` + command_name function/macro for buildin see. https://github.com/Kitware/CMake/blob/2d0b7798dbaa5625496907a97973087be8db5f53/Source/cmState.cxx#L521