### PR TITLE
Compute CMAKE_PROGRAM_PATH from returned json

### DIFF
--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -470,7 +470,7 @@ macro(conan_set_program_path)
         string(JSON _dep_binary GET ${conan_stdout} graph nodes ${_node_number} binary)
         string(JSON _dep_context GET ${conan_stdout} graph nodes ${_node_number} context)
         
-        if(NOT _dep_binary STREQUAL "Cache" OR NOT _dep_context STREQUAL "build")
+        if(_dep_binary STREQUAL "Skip" OR NOT _dep_context STREQUAL "build")
             continue()
         endif()
 
@@ -488,7 +488,6 @@ macro(conan_set_program_path)
         endforeach()
     endforeach()
 
-    message("conan_program_path: ${_CONAN_PROGRAM_PATH}")
     list(REMOVE_DUPLICATES _CONAN_PROGRAM_PATH)
 endmacro()
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -4,7 +4,17 @@ project(FormatOutput LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 14)
 
+set(CMAKE_PROGRAM_PATH "/path/to/foo/bar")
+
 find_package(fmt REQUIRED)
+
+message("CMAKE_PROGRAM_PATH: ${CMAKE_PROGRAM_PATH}")
+find_program(CMAKE_CXX_CPPCHECK cppcheck NAMES cppcheck)
+if(NOT CMAKE_CXX_CPPCHECK)
+    message(FATAL_ERROR "Unable to locate CPPCHECK")
+else()
+    message("Cppcheck found: ${CMAKE_CXX_CPPCHECK}")
+endif()
 
 add_executable(main main.cpp)
 target_link_libraries(main PRIVATE fmt::fmt)

--- a/example/conanfile.txt
+++ b/example/conanfile.txt
@@ -1,5 +1,8 @@
 [requires]
-fmt/9.1.0
+fmt/[>10]
+
+[tool_requires]
+cppcheck/[>=2.13 <3]
 
 [layout]
 cmake_layout


### PR DESCRIPTION
This might work to set this _after_ the first call to `find_package` (as the known limitation). 

The implementation in `CMakeToolchain` is:
```
        build_req = self._conanfile.dependencies.build.values()
        build_bin_paths = []
        for req in build_req:
            cppinfo = req.cpp_info.aggregated_components()
            build_paths.extend(cppinfo.builddirs)
            build_bin_paths.extend(cppinfo.bindirs)
```

This is just an approximation by relying on the json alone.
