### PR TITLE
Add support for MinGW Clang

### DIFF
--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -171,7 +171,7 @@ function(detect_lib_cxx LIB_CXX)
         set(${LIB_CXX} "libstdc++${_CONAN_GNU_LIBSTDCXX_SUFFIX}" PARENT_SCOPE)
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
         set(${LIB_CXX} "libc++" PARENT_SCOPE)
-    elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT MSVC)
         # Check for libc++
         detect_libcxx()
         if(_CONAN_IS_LIBCXX)


### PR DESCRIPTION
The C++ runtime is not detected correctly for MinGW Clang and Conan assumes the compiler to be ClangCL otherwise.

Here's a CI run after the fix: https://github.com/novatel/novatel_edie/actions/runs/9062747744/job/24897263836#step:6:87