### PR TITLE
[feature] Add CONAN_DOWNLOAD and CONAN_ISOLATE_HOME optional features

### DIFF
--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -507,7 +507,7 @@ function(conan_get_version conan_command conan_current_version)
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
     if(conan_result)
-        message(FATAL_ERROR "CMake-Conan: Error when trying to run Conan")
+        message(FATAL_ERROR "CMake-Conan: Error when trying to run '${conan_command} --version'")
     endif()
 
     string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" conan_version ${conan_output})

--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -532,7 +532,7 @@ function(conan_version_check)
     if(NOT CONAN_VERSION_CHECK_MINIMUM)
         message(FATAL_ERROR "CMake-Conan: Required parameter MINIMUM not set!")
     endif()
-        if(NOT CONAN_VERSION_CHECK_CURRENT)
+    if(NOT CONAN_VERSION_CHECK_CURRENT)
         message(FATAL_ERROR "CMake-Conan: Required parameter CURRENT not set!")
     endif()
 

--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -535,6 +535,15 @@ function(conan_version_check)
 endfunction()
 
 
+function(get_latest_conan_version VERSION_VARIABLE)
+    set(json_file "${CMAKE_BINARY_DIR}/conan_latest_release.json")
+    file(DOWNLOAD "https://api.github.com/repos/conan-io/conan/releases/latest" "${json_file}")
+    file(READ "${json_file}" json)
+    string(REGEX MATCH "\"tag_name\": \"([^\"]+)\"" _ "${json}")
+    set(${VERSION_VARIABLE} "${CMAKE_MATCH_1}" PARENT_SCOPE)
+endfunction()
+
+
 macro(construct_profile_argument argument_variable profile_list)
     set(${argument_variable} "")
     if("${profile_list}" STREQUAL "CONAN_HOST_PROFILE")

--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -556,9 +556,20 @@ endfunction()
 
 function(get_latest_conan_version VERSION_VARIABLE)
     set(json_file "${CMAKE_BINARY_DIR}/conan_latest_release.json")
-    file(DOWNLOAD "https://api.github.com/repos/conan-io/conan/releases/latest" "${json_file}")
-    file(READ "${json_file}" json)
+    file(DOWNLOAD "https://api.github.com/repos/conan-io/conan/releases/latest"
+                  "${json_file}"
+                  INACTIVITY_TIMEOUT 5
+                  STATUS status)
+    list(GET status 0 status_code)
+    if(NOT status_code EQUAL 0)
+        list(GET status 1 message)
+        message(FATAL_ERROR "CMake-Conan: Failed to get the latest Conan version info: ${message} (${status_code})")
+    endif()
+    file(READ "${json_file}" json ENCODING UTF-8)
     string(REGEX MATCH "\"tag_name\": \"([^\"]+)\"" _ "${json}")
+    if(NOT _)
+        message(FATAL_ERROR "CMake-Conan: Failed to parse the latest Conan version info from: '${json_file}'")
+    endif()
     set(${VERSION_VARIABLE} "${CMAKE_MATCH_1}" PARENT_SCOPE)
 endfunction()
 

--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -20,7 +20,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-set(CONAN_MINIMUM_VERSION 2.0.5)
+# Configurable variables
+set(CONAN_MINIMUM_VERSION "2.0.5" CACHE STRING "Minimum required Conan version")
+set(CONAN_HOST_PROFILE "default;auto-cmake" CACHE STRING "Conan host profile")
+set(CONAN_BUILD_PROFILE "default" CACHE STRING "Conan build profile")
+set(CONAN_INSTALL_ARGS "--build=missing" CACHE STRING "Command line arguments for conan install")
+set(CONAN_DOWNLOAD "if-missing" CACHE STRING "Download the Conan client (always, if-missing or never)")
+set(CONAN_DOWNLOAD_VERSION "latest" CACHE STRING "Download a specific Conan version")
+set(CONAN_ISOLATE_HOME "if-downloaded" CACHE STRING "Set $CONAN_HOME to \${CMAKE_BINARY_DIR}/conan_home (always, if-downloaded or never)")
 
 # Create a new policy scope and set the minimum required cmake version so the
 # features behind a policy setting like if(... IN_LIST ...) behaves as expected
@@ -456,7 +463,7 @@ function(conan_install)
     set(CONAN_OUTPUT_FOLDER ${CMAKE_BINARY_DIR}/conan)
     # Invoke "conan install" with the provided arguments
     set(CONAN_ARGS ${CONAN_ARGS} -of=${CONAN_OUTPUT_FOLDER})
-    message(STATUS "CMake-Conan: conan install ${CMAKE_SOURCE_DIR} ${CONAN_ARGS} ${ARGN}")
+    message(STATUS "CMake-Conan: ${CONAN_COMMAND} install ${CMAKE_SOURCE_DIR} ${CONAN_ARGS} ${ARGN}")
 
 
     # In case there was not a valid cmake executable in the PATH, we inject the
@@ -517,7 +524,7 @@ endfunction()
 
 function(conan_version_check)
     set(options )
-    set(oneValueArgs MINIMUM CURRENT)
+    set(oneValueArgs MINIMUM CURRENT RESULT)
     set(multiValueArgs )
     cmake_parse_arguments(CONAN_VERSION_CHECK
         "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -530,7 +537,19 @@ function(conan_version_check)
     endif()
 
     if(CONAN_VERSION_CHECK_CURRENT VERSION_LESS CONAN_VERSION_CHECK_MINIMUM)
-        message(FATAL_ERROR "CMake-Conan: Conan version must be ${CONAN_VERSION_CHECK_MINIMUM} or later")
+        if(CONAN_VERSION_CHECK_RESULT)
+            set(${CONAN_VERSION_CHECK_RESULT} FALSE PARENT_SCOPE)
+        endif()
+        if(CONAN_DOWNLOAD STREQUAL "if-missing")
+            message(STATUS "CMake-Conan: Found Conan but its version (${CONAN_VERSION_CHECK_CURRENT}) is older than "
+                           "required (${CONAN_VERSION_CHECK_MINIMUM}). Will download the latest version instead.")
+        else()
+            message(FATAL_ERROR "CMake-Conan: Conan version must be ${CONAN_VERSION_CHECK_MINIMUM} or later")
+        endif()
+    else()
+        if(CONAN_VERSION_CHECK_RESULT)
+            set(${CONAN_VERSION_CHECK_RESULT} TRUE PARENT_SCOPE)
+        endif()
     endif()
 endfunction()
 
@@ -584,7 +603,7 @@ function(download_conan)
     set(CONAN_FILE "conan-${CONAN_VERSION}-${HOST_OS}-${HOST_ARCH}.${FILE_EXT}")
     set(CONAN_URL "https://github.com/conan-io/conan/releases/download/${CONAN_VERSION}/${CONAN_FILE}")
 
-    message(STATUS "Downloading Conan ${CONAN_VERSION} from ${CONAN_URL}")
+    message(STATUS "CMake-Conan: Downloading Conan ${CONAN_VERSION} from ${CONAN_URL}")
     include(FetchContent)
     FetchContent_Declare(
         Conan
@@ -619,9 +638,37 @@ macro(conan_provide_dependency method package_name)
     set_property(GLOBAL PROPERTY CONAN_PROVIDE_DEPENDENCY_INVOKED TRUE)
     get_property(_conan_install_success GLOBAL PROPERTY CONAN_INSTALL_SUCCESS)
     if(NOT _conan_install_success)
-        find_program(CONAN_COMMAND "conan" REQUIRED)
-        conan_get_version(${CONAN_COMMAND} CONAN_CURRENT_VERSION)
-        conan_version_check(MINIMUM ${CONAN_MINIMUM_VERSION} CURRENT ${CONAN_CURRENT_VERSION})
+        if(NOT CONAN_DOWNLOAD STREQUAL "always")
+            find_program(CONAN_COMMAND "conan" QUIET)
+            if(CONAN_COMMAND)
+                conan_get_version(${CONAN_COMMAND} CONAN_CURRENT_VERSION)
+                conan_version_check(MINIMUM ${CONAN_MINIMUM_VERSION} CURRENT ${CONAN_CURRENT_VERSION}
+                                    RESULT _conan_version_check_result)
+                if(NOT _conan_version_check_result)
+                    set(CONAN_COMMAND "-NOTFOUND")
+                endif()
+            endif()
+        endif()
+        if(NOT CONAN_COMMAND)
+            if(CONAN_DOWNLOAD STREQUAL "never")
+                message(FATAL_ERROR "CMake-Conan: Conan executable not found. "
+                                    "Please install Conan, set CONAN_COMMAND or enable CONAN_DOWNLOAD")
+            endif()
+            if(CONAN_DOWNLOAD_VERSION STREQUAL "latest")
+                get_latest_conan_version(_download_version)
+            else()
+                set(_download_version ${CONAN_DOWNLOAD_VERSION})
+            endif()
+            download_conan(VERSION ${_download_version} DESTINATION "${CMAKE_BINARY_DIR}/conan_client")
+            set(CONAN_COMMAND "${CMAKE_BINARY_DIR}/conan_client/conan")
+            set(_conan_downloaded TRUE)
+        endif()
+
+        if(CONAN_ISOLATE_HOME STREQUAL "always" OR (CONAN_ISOLATE_HOME STREQUAL "if-downloaded" AND _conan_downloaded))
+            message(STATUS "CMake-Conan: Setting CONAN_HOME to '${CMAKE_BINARY_DIR}/conan_home'")
+            set(ENV{CONAN_HOME} "${CMAKE_BINARY_DIR}/conan_home")
+        endif()
+
         message(STATUS "CMake-Conan: first find_package() found. Installing dependencies with Conan")
         if("default" IN_LIST CONAN_HOST_PROFILE OR "default" IN_LIST CONAN_BUILD_PROFILE)
             conan_profile_detect_default()
@@ -721,11 +768,6 @@ endmacro()
 # Add a deferred call at the end of processing the top-level directory
 # to check if the dependency provider was invoked at all.
 cmake_language(DEFER DIRECTORY "${CMAKE_SOURCE_DIR}" CALL conan_provide_dependency_check)
-
-# Configurable variables for Conan profiles
-set(CONAN_HOST_PROFILE "default;auto-cmake" CACHE STRING "Conan host profile")
-set(CONAN_BUILD_PROFILE "default" CACHE STRING "Conan build profile")
-set(CONAN_INSTALL_ARGS "--build=missing" CACHE STRING "Command line arguments for conan install")
 
 find_program(_cmake_program NAMES cmake NO_PACKAGE_ROOT_PATH NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH NO_CMAKE_FIND_ROOT_PATH)
 if(NOT _cmake_program)

--- a/tests/resources/download/auto_download/CMakeLists.txt
+++ b/tests/resources/download/auto_download/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.24)
+project(MyApp CXX)
+
+find_package(hello REQUIRED)
+add_executable(app main.cpp)
+target_link_libraries(app hello::hello)

--- a/tests/resources/download/auto_download/conanfile.txt
+++ b/tests/resources/download/auto_download/conanfile.txt
@@ -1,0 +1,5 @@
+[requires]
+hello/0.1
+
+[generators]
+CMakeDeps

--- a/tests/resources/download/download_function/CMakeLists.txt
+++ b/tests/resources/download/download_function/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.24)
+project(MyApp CXX)
+
+get_latest_conan_version(LATEST_CONAN_VERSION)
+message(STATUS "Latest Conan version: ${LATEST_CONAN_VERSION}")
+download_conan(VERSION ${LATEST_CONAN_VERSION} DESTINATION ${CMAKE_BINARY_DIR}/conan)

--- a/tests/resources/download/download_function/conanfile.txt
+++ b/tests/resources/download/download_function/conanfile.txt
@@ -1,0 +1,2 @@
+[requires]
+hello/0.1

--- a/tests/resources/download/download_function/conanfile.txt
+++ b/tests/resources/download/download_function/conanfile.txt
@@ -1,2 +1,1 @@
 [requires]
-hello/0.1

--- a/tests/resources/download/get_latest_version/CMakeLists.txt
+++ b/tests/resources/download/get_latest_version/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.24)
+project(MyApp CXX)
+
+get_latest_conan_version(LATEST_CONAN_VERSION)
+message(STATUS "Latest Conan version: ${LATEST_CONAN_VERSION}")

--- a/tests/resources/download/get_latest_version/conanfile.txt
+++ b/tests/resources/download/get_latest_version/conanfile.txt
@@ -1,0 +1,2 @@
+[requires]
+hello/0.1

--- a/tests/resources/download/get_latest_version/conanfile.txt
+++ b/tests/resources/download/get_latest_version/conanfile.txt
@@ -1,2 +1,1 @@
 [requires]
-hello/0.1

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -755,3 +755,13 @@ class TestTryCompile:
         run(f'cmake -S {source_dir} -B {binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider}')
         out, _ = capfd.readouterr()
         assert 'Performing Test HELLO_WORLD_CAN_COMPILE - Success' in out
+
+
+class TestDownload:
+    def test_get_latest_version(self, capfd, basic_cmake_project):
+        source_dir, binary_dir = basic_cmake_project
+        shutil.copytree(src_dir / 'tests' / 'resources' / 'download' / 'get_latest_version', source_dir, dirs_exist_ok=True)
+        run(f'cmake -S {source_dir} -B {binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider}')
+        out, _ = capfd.readouterr()
+        assert re.search(r'Latest Conan version: \d+\.\d+\.\d+', out)
+

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -765,3 +765,11 @@ class TestDownload:
         out, _ = capfd.readouterr()
         assert re.search(r'Latest Conan version: \d+\.\d+\.\d+', out)
 
+    def test_download_function(self, capfd, basic_cmake_project):
+        source_dir, binary_dir = basic_cmake_project
+        shutil.copytree(src_dir / 'tests' / 'resources' / 'download' / 'download_function', source_dir, dirs_exist_ok=True)
+        run(f'cmake -S {source_dir} -B {binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider}')
+        out, _ = capfd.readouterr()
+        assert 'Downloading Conan ' in out
+        assert (os.path.exists(os.path.join(binary_dir, 'conan', 'conan')) or
+                os.path.exists(os.path.join(binary_dir, 'conan', 'conan.exe')))


### PR DESCRIPTION
One quite frequent complaint about Conan, especially from Windows users, is that it requires a Python installation with Conan installed, which adds friction to the build process. This PR proposes a simple fix to that: optionally download and use one of the self-contained Conan packages from https://github.com/conan-io/conan/releases/latest, if Conan is not found on the system. The config options for this feature are `always`, `if-missing` and `never`.

In addition to that, it also adds an option to override CONAN_HOME to a folder inside the build dir. This might be useful in other scenarios as well, but if Conan is not available on the system or it's an outdated version, then it's generally preferable if the build process does not add unexpected files to `~/.conan2`. Its config options are `always`, `if-downloaded` and `never`.

Whether the default config options for these features should be `if-missing` and `if-downloaded`, respectively, or `never` and `never` is debatable, but I preferred and set them to the prior one.

The added tests should cover both of these features comprehensively, I believe.

I also moved all config options of `conan_provider.cmake` to the top of the file for better visibility.