### PR TITLE
Set compiler.cstd in host profile

### DIFF
--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-set(CONAN_MINIMUM_VERSION 2.0.5)
+set(CONAN_MINIMUM_VERSION 2.4.0)
 
 # Create a new policy scope and set the minimum required cmake version so the
 # features behind a policy setting like if(... IN_LIST ...) behaves as expected
@@ -125,6 +125,14 @@ function(detect_arch arch)
     endif()
     message(STATUS "CMake-Conan: cmake_system_processor=${_arch}")
     set(${arch} ${_arch} PARENT_SCOPE)
+endfunction()
+
+
+function(detect_c_standard c_standard)
+    set(${c_standard} ${CMAKE_C_STANDARD} PARENT_SCOPE)
+    if(CMAKE_C_EXTENSIONS)
+        set(${c_standard} "gnu${CMAKE_C_STANDARD}" PARENT_SCOPE)
+    endif()
 endfunction()
 
 
@@ -363,6 +371,7 @@ function(detect_host_profile output_file)
     detect_os(os os_api_level os_sdk os_subsystem os_version)
     detect_arch(arch)
     detect_compiler(compiler compiler_version compiler_runtime compiler_runtime_type)
+    detect_c_standard(compiler_cstd)
     detect_cxx_standard(compiler_cppstd)
     detect_lib_cxx(compiler_libcxx)
     detect_build_type(build_type)
@@ -398,6 +407,9 @@ function(detect_host_profile output_file)
     endif()
     if(compiler_runtime_type)
         string(APPEND profile compiler.runtime_type=${compiler_runtime_type} "\n")
+    endif()
+    if(compiler_cstd)
+        string(APPEND profile compiler.cstd=${compiler_cstd} "\n")
     endif()
     if(compiler_cppstd)
         string(APPEND profile compiler.cppstd=${compiler_cppstd} "\n")


### PR DESCRIPTION
The `cstd` setting was added to Conan in v2.4.0. Similar to `cppstd`, it is used to indicate the selected C language standard.

~The branch of this PR is based upon the `tidy-ups` branch from #656, which has not yet been merged to `develop2`, hence why the additional patches are also visible.~