### PR TITLE
ci tests: install libc++ on ubuntu

### DIFF
--- a/.github/workflows/cmake_conan.yml
+++ b/.github/workflows/cmake_conan.yml
@@ -20,6 +20,9 @@ jobs:
         uses: actions/setup-python@v4.6.0
         with:
           python-version: "3.10"
+      - name: Install libc++ on Ubuntu
+        run: sudo apt-get update && sudo apt-get install -y libc++-dev libc++abi-dev
+        if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Install autotools on macOS
         run: brew install automake
         if: ${{ matrix.os == 'macos-13' }}


### PR DESCRIPTION
Ensure libc++ is installed on the ubuntu image as it is required by one of the tests