### PR TITLE
feat: add `CONAN_OUTPUT_PATH`

### DIFF
--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -455,7 +455,7 @@ endfunction()
 
 function(conan_install)
     cmake_parse_arguments(ARGS conan_args ${ARGN})
-    set(conan_output_folder ${CMAKE_BINARY_DIR}/conan)
+    set(conan_output_folder "${CMAKE_BINARY_DIR}/${CONAN_OUTPUT_PATH}")
     # Invoke "conan install" with the provided arguments
     set(conan_args ${conan_args} -of=${conan_output_folder})
     message(STATUS "CMake-Conan: conan install ${CMAKE_SOURCE_DIR} ${conan_args} ${ARGN}")
@@ -666,6 +666,7 @@ cmake_language(DEFER DIRECTORY "${CMAKE_SOURCE_DIR}" CALL conan_provide_dependen
 set(CONAN_HOST_PROFILE "default;auto-cmake" CACHE STRING "Conan host profile")
 set(CONAN_BUILD_PROFILE "default" CACHE STRING "Conan build profile")
 set(CONAN_INSTALL_ARGS "--build=missing" CACHE STRING "Command line arguments for conan install")
+set(CONAN_OUTPUT_PATH "conan" CACHE STRING "The output path relative to the CMake build directory")
 
 find_program(_cmake_program NAMES cmake NO_PACKAGE_ROOT_PATH NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH NO_CMAKE_FIND_ROOT_PATH)
 if(NOT _cmake_program)


### PR DESCRIPTION
When using `copy(self, "*.dll", dep.cpp_info.bindir, self.build_folder)` in a project, the function expects the output directory to be the CMake build directory. `CONAN_OUTPUT_PATH` defaults to `conan` but can be set to an empty string for conan to output to the CMake build directory.