### PR TITLE
github actions: update runners and actions

### DIFF
--- a/.github/workflows/cmake_conan.yml
+++ b/.github/workflows/cmake_conan.yml
@@ -24,7 +24,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libc++-dev libc++abi-dev
         if: ${{ matrix.os == 'ubuntu-24.04' }}
       - name: Install autotools on macOS
-        run: brew install automake
+        run: brew install automake libtool
         if: ${{ matrix.os == 'macos-15' }}
       - name: Install Conan
         run: pip install conan pytest && conan --version

--- a/.github/workflows/cmake_conan.yml
+++ b/.github/workflows/cmake_conan.yml
@@ -4,11 +4,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2025, macos-15, ubuntu-latest]
+        os: [windows-2025, macos-15, ubuntu-24.04]
         include:
           - os: windows-2025
           - os: macos-15
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4.2.2
       - uses: ilammy/msvc-dev-cmd@v1
@@ -22,7 +22,7 @@ jobs:
           python-version: "3.10"
       - name: Install libc++ on Ubuntu
         run: sudo apt-get update && sudo apt-get install -y libc++-dev libc++abi-dev
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-24.04' }}
       - name: Install autotools on macOS
         run: brew install automake
         if: ${{ matrix.os == 'macos-15' }}
@@ -36,7 +36,7 @@ jobs:
       - name: Run Tests
         run: pytest -rA -v
   example:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Setup Python

--- a/.github/workflows/cmake_conan.yml
+++ b/.github/workflows/cmake_conan.yml
@@ -4,20 +4,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2019, macos-13, ubuntu-latest]
+        os: [windows-2025, macos-15, ubuntu-latest]
         include:
-          - os: windows-2019
-          - os: macos-13
+          - os: windows-2025
+          - os: macos-15
           - os: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.2
+      - uses: actions/checkout@v4.2.2
       - uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: amd64
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-2025' }}
         name: setup msvc vcvars
       - name: Setup Python
-        uses: actions/setup-python@v4.6.0
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: "3.10"
       - name: Install libc++ on Ubuntu
@@ -25,30 +25,30 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Install autotools on macOS
         run: brew install automake
-        if: ${{ matrix.os == 'macos-13' }}
+        if: ${{ matrix.os == 'macos-15' }}
       - name: Install Conan
         run: pip install conan pytest && conan --version
       - name: Setup CMake and Ninja
         uses: lukka/get-cmake@latest
         with:
-          cmakeVersion: "~3.25.0"
+          cmakeVersion: "~3.31.7"
           ninjaVersion: "^1.11.1"
       - name: Run Tests
         run: pytest -rA -v
   example:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.2
+      - uses: actions/checkout@v4.2.2
       - name: Setup Python
-        uses: actions/setup-python@v4.6.0
+        uses: actions/setup-python@v5.6.0
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install Conan
         run: pip install conan && conan --version
       - name: Setup CMake and Ninja
         uses: lukka/get-cmake@latest
         with:
-          cmakeVersion: "~3.25.0"
+          cmakeVersion: "~3.31.7"
           ninjaVersion: "^1.11.1"
       - name: Configure CMake
         run: cmake -B build -S . -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=../conan_provider.cmake -DCMAKE_BUILD_TYPE=Release

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -689,28 +689,28 @@ class TestMSVCArch:
     @windows
     def test_msvc_arm64(self, capfd, basic_cmake_project):
         source_dir, binary_dir = basic_cmake_project
-        run(f'cmake -S {source_dir} -B {binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider} -G "Visual Studio 16 2019" -A ARM64')
+        run(f'cmake -S {source_dir} -B {binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider} -G "Visual Studio 17 2022" -A ARM64')
         out, _ = capfd.readouterr()
         assert "arch=armv8" in out
 
     @windows
     def test_msvc_arm(self, capfd, basic_cmake_project):
         source_dir, binary_dir = basic_cmake_project
-        run(f'cmake -S {source_dir} -B {binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider} -G "Visual Studio 16 2019" -A ARM')
+        run(f'cmake -S {source_dir} -B {binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider} -G "Visual Studio 17 2022" -A ARM')
         out, _ = capfd.readouterr()
         assert "arch=armv7" in out
 
     @windows
     def test_msvc_x86_64(self, capfd, basic_cmake_project):
         source_dir, binary_dir = basic_cmake_project
-        run(f'cmake -S {source_dir} -B {binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider} -G "Visual Studio 16 2019" -A x64')
+        run(f'cmake -S {source_dir} -B {binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider} -G "Visual Studio 17 2022" -A x64')
         out, _ = capfd.readouterr()
         assert "arch=x86_64" in out
 
     @windows
     def test_msvc_x86(self, capfd, basic_cmake_project):
         source_dir, binary_dir = basic_cmake_project
-        run(f'cmake -S {source_dir} -B {binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider} -G "Visual Studio 16 2019" -A Win32')
+        run(f'cmake -S {source_dir} -B {binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider} -G "Visual Studio 17 2022" -A Win32')
         out, _ = capfd.readouterr()
         assert "arch=x86" in out
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -694,13 +694,6 @@ class TestMSVCArch:
         assert "arch=armv8" in out
 
     @windows
-    def test_msvc_arm(self, capfd, basic_cmake_project):
-        source_dir, binary_dir = basic_cmake_project
-        run(f'cmake -S {source_dir} -B {binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider} -G "Visual Studio 17 2022" -A ARM')
-        out, _ = capfd.readouterr()
-        assert "arch=armv7" in out
-
-    @windows
     def test_msvc_x86_64(self, capfd, basic_cmake_project):
         source_dir, binary_dir = basic_cmake_project
         run(f'cmake -S {source_dir} -B {binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider} -G "Visual Studio 17 2022" -A x64')


### PR DESCRIPTION
- Update github actions runners to most recently available images
- fixups: install missing libtool homebrew dependency on macos, use visual studio 2022, stop testing 32-bit arm on Windows