### PR TITLE
Use CMAKE_TOOLCHAIN_FILE if provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ ENV/
 env.bak/
 venv.bak/
 example/arm-none-eabi/.vs
+example/arm-none-eabi/gcc_arm_none_eabi
+example/arm-none-eabi/downloads

--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,3 @@ ENV/
 env.bak/
 venv.bak/
 example/arm-none-eabi/.vs
-example/arm-none-eabi/gcc_arm_none_eabi
-example/arm-none-eabi/downloads

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+example/arm-none-eabi/.vs

--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -425,6 +425,17 @@ function(detect_host_profile output_file)
     string(APPEND profile "[conf]\n")
     string(APPEND profile "tools.cmake.cmaketoolchain:generator=${CMAKE_GENERATOR}\n")
 
+    # if a custom cmake toolchain was specified use it
+    if(CMAKE_TOOLCHAIN_FILE AND NOT EXISTS ${CMAKE_TOOLCHAIN_FILE})
+      message(FATAL_ERROR "Specified toolchian file ${CMAKE_TOOLCHAIN_FILE} does not exist")
+    endif()
+
+    if(CMAKE_TOOLCHAIN_FILE AND EXISTS ${CMAKE_TOOLCHAIN_FILE})
+      # pass cmake toolchain file to conan
+      string(APPEND profile "tools.cmake.cmaketoolchain:toolchain_file=${CMAKE_TOOLCHAIN_FILE}\n")
+  endif()
+
+
     # propagate compilers via profile
     append_compiler_executables_configuration()
 

--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -426,11 +426,7 @@ function(detect_host_profile output_file)
     string(APPEND profile "tools.cmake.cmaketoolchain:generator=${CMAKE_GENERATOR}\n")
 
     # if a custom cmake toolchain was specified use it
-    if(CMAKE_TOOLCHAIN_FILE AND NOT EXISTS ${CMAKE_TOOLCHAIN_FILE})
-      message(FATAL_ERROR "Specified toolchian file ${CMAKE_TOOLCHAIN_FILE} does not exist")
-    endif()
-
-    if(CMAKE_TOOLCHAIN_FILE AND EXISTS ${CMAKE_TOOLCHAIN_FILE})
+    if(CMAKE_TOOLCHAIN_FILE)
       # pass cmake toolchain file to conan
       string(APPEND profile "tools.cmake.cmaketoolchain:toolchain_file=${CMAKE_TOOLCHAIN_FILE}\n")
     endif()

--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -433,7 +433,7 @@ function(detect_host_profile output_file)
     if(CMAKE_TOOLCHAIN_FILE AND EXISTS ${CMAKE_TOOLCHAIN_FILE})
       # pass cmake toolchain file to conan
       string(APPEND profile "tools.cmake.cmaketoolchain:toolchain_file=${CMAKE_TOOLCHAIN_FILE}\n")
-  endif()
+    endif()
 
 
     # propagate compilers via profile

--- a/example/arm-none-eabi/CMakeLists.txt
+++ b/example/arm-none-eabi/CMakeLists.txt
@@ -1,0 +1,61 @@
+﻿
+cmake_minimum_required (VERSION 3.30)
+
+
+
+project ("arm-none-eabi")
+
+set(EXE_NAME arm_none_eabi_test)
+
+set(CMAKE_EXECUTABLE_SUFFIX ".elf")
+set(EXE_SOURCES "main.c" "syscall_wrapper.h" "syscall_wrapper.c" "fmt_dummy.h" "fmt_dummy.cpp")
+
+list(APPEND EXE_SOURCES "startup_stm32f429xx.s")
+# Cmake does not seam to recognise *.s files as ASM. Tell Cmake the language
+set_source_files_properties("target/startup_stm32f429xx.s"
+                            PROPERTIES LANGUAGE ASM)
+
+find_program(CMAKE_SIZE arm-none-eabi-size)
+if(NOT CMAKE_SIZE)
+  message(FATAL_ERROR "Could not find 'arm-none-eabi-size'. Please install it or set CMAKE_SIZE manually.")
+endif()
+
+set(LINKER_SCRIPT_PATH "${CMAKE_CURRENT_LIST_DIR}/STM32F429XX_FLASH.ld")
+
+# Check file existance
+if(NOT EXISTS ${LINKER_SCRIPT_PATH})
+  message(FATAL_ERROR "Linker Script does not exist. Path = ${LINKER_SCRIPT_PATH}")
+endif()
+
+add_link_options(-T${LINKER_SCRIPT_PATH} -Wl,--gc-sections  -Wl,-Map=${PROJECT_NAME}.map)
+
+
+
+find_package(fmt REQUIRED)
+
+add_executable(${EXE_NAME} ${EXE_SOURCES})
+
+# create an alias target if fmt is used in header only mode
+if(NOT TARGET fmt::fmt AND TARGET fmt::fmt-header-only)
+  add_library(fmt::fmt ALIAS fmt::fmt-header-only)
+endif()
+
+target_link_libraries(${EXE_NAME} PUBLIC fmt::fmt)
+
+set(WRAPPED_SYMBOLS malloc free realloc calloc)
+
+set(WRAP_OPTIONS "")
+foreach(SYM IN LISTS WRAPPED_SYMBOLS)
+  list(APPEND WRAP_OPTIONS "-Wl,--wrap=${SYM}")
+endforeach()
+
+set(LINKER_STATS_OPTIONS "-Wl,--print-memory-usage")
+
+target_link_options(${EXE_NAME} PUBLIC ${WRAP_OPTIONS}
+                    ${LINKER_STATS_OPTIONS})
+
+add_custom_command(
+  TARGET ${EXE_NAME}
+  POST_BUILD
+  COMMAND ${CMAKE_SIZE} $<TARGET_FILE:${EXE_NAME}>
+  COMMENT "Memory usage summary")

--- a/example/arm-none-eabi/CMakePresets.json
+++ b/example/arm-none-eabi/CMakePresets.json
@@ -1,0 +1,49 @@
+﻿{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "_conan",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_PROJECT_TOP_LEVEL_INCLUDES": "${sourceDir}/../../conan_provider.cmake"
+      }
+    },
+    {
+      "name": "_arm_none_eabi",
+      "inherits": "_conan",
+      "hidden": true,
+      "toolchainFile": "${sourceDir}/gcc-arm-none-eabi.cmake",
+      "cacheVariables": {
+        "BUILD_TARGET": true,
+        "COMPILER_ARCH_FLAGS": "-mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=hard"
+      }
+    },
+    {
+      "name": "arm_none_eabi_gcc_14_win",
+      "description": "Windows Cross Compiler",
+      "inherits": [ "_arm_none_eabi" ],
+      "cacheVariables": {
+        "TOOLCHAIN_URL": "https://developer.arm.com/-/media/Files/downloads/gnu/14.3.rel1/binrel/arm-gnu-toolchain-14.3.rel1-mingw-w64-i686-arm-none-eabi.zip"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
+      "name": "arm_none_eabi_gcc_14_linux",
+      "description": "Linux Cross Compiler",
+      "hidden": true,
+      "inherits": [ "_arm_none_eabi" ],
+      "cacheVariables": {
+        "TOOLCHAIN_URL": "https://developer.arm.com/-/media/Files/downloads/gnu/14.3.rel1/binrel/arm-gnu-toolchain-14.3.rel1-x86_64-arm-none-eabi.tar.xz",
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    }
+  ]
+}

--- a/example/arm-none-eabi/CMakePresets.json
+++ b/example/arm-none-eabi/CMakePresets.json
@@ -38,7 +38,7 @@
       "hidden": true,
       "inherits": [ "_arm_none_eabi" ],
       "cacheVariables": {
-        "TOOLCHAIN_URL": "https://developer.arm.com/-/media/Files/downloads/gnu/14.3.rel1/binrel/arm-gnu-toolchain-14.3.rel1-x86_64-arm-none-eabi.tar.xz",
+        "TOOLCHAIN_URL": "https://developer.arm.com/-/media/Files/downloads/gnu/14.3.rel1/binrel/arm-gnu-toolchain-14.3.rel1-x86_64-arm-none-eabi.tar.xz"
       },
       "condition": {
         "type": "equals",

--- a/example/arm-none-eabi/CMakePresets.json
+++ b/example/arm-none-eabi/CMakePresets.json
@@ -9,8 +9,17 @@
       }
     },
     {
+      "name": "_dir",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/out/${presetName}/build",
+      "installDir": "${sourceDir}/out/${presetName}/install",
+      "cacheVariables": {
+        "REPORTS_DIR": "${sourceDir}/out/${presetName}/reports"
+      }
+    },
+    {
       "name": "_arm_none_eabi",
-      "inherits": "_conan",
+      "inherits": [ "_conan", "_dir" ],
       "hidden": true,
       "generator": "Ninja Multi-Config",
       "toolchainFile": "${sourceDir}/gcc-arm-none-eabi.cmake",

--- a/example/arm-none-eabi/CMakePresets.json
+++ b/example/arm-none-eabi/CMakePresets.json
@@ -12,6 +12,7 @@
       "name": "_arm_none_eabi",
       "inherits": "_conan",
       "hidden": true,
+      "generator": "Ninja Multi-Config",
       "toolchainFile": "${sourceDir}/gcc-arm-none-eabi.cmake",
       "cacheVariables": {
         "BUILD_TARGET": true,
@@ -44,6 +45,32 @@
         "lhs": "${hostSystemName}",
         "rhs": "Linux"
       }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "arm_none_eabi_gcc_14_win_dbg",
+      "configurePreset": "arm_none_eabi_gcc_14_win",
+      "displayName": "Debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "arm_none_eabi_gcc_14_win_rel",
+      "configurePreset": "arm_none_eabi_gcc_14_win",
+      "displayName": "Release",
+      "configuration": "Release"
+    },
+    {
+      "name": "arm_none_eabi_gcc_14_linux_dbg",
+      "configurePreset": "arm_none_eabi_gcc_14_linux",
+      "displayName": "Debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "arm_none_eabi_gcc_14_linux_rel",
+      "configurePreset": "arm_none_eabi_gcc_14_linux",
+      "displayName": "Release",
+      "configuration": "Release"
     }
   ]
 }

--- a/example/arm-none-eabi/STM32F429XX_FLASH.ld
+++ b/example/arm-none-eabi/STM32F429XX_FLASH.ld
@@ -1,0 +1,269 @@
+/*
+******************************************************************************
+**
+
+**  File        : LinkerScript.ld
+**
+**  Author		: STM32CubeMX
+**
+**  Abstract    : Linker script for STM32F429ZITx series
+**                2048Kbytes FLASH and 256Kbytes RAM
+**
+**                Set heap size, stack size and stack location according
+**                to application requirements.
+**
+**                Set memory bank area and size if external memory is used.
+**
+**  Target      : STMicroelectronics STM32
+**
+**  Distribution: The file is distributed “as is,” without any warranty
+**                of any kind.
+**
+*****************************************************************************
+** @attention
+**
+** <h2><center>&copy; COPYRIGHT(c) 2025 STMicroelectronics</center></h2>
+**
+** Redistribution and use in source and binary forms, with or without modification,
+** are permitted provided that the following conditions are met:
+**   1. Redistributions of source code must retain the above copyright notice,
+**      this list of conditions and the following disclaimer.
+**   2. Redistributions in binary form must reproduce the above copyright notice,
+**      this list of conditions and the following disclaimer in the documentation
+**      and/or other materials provided with the distribution.
+**   3. Neither the name of STMicroelectronics nor the names of its contributors
+**      may be used to endorse or promote products derived from this software
+**      without specific prior written permission.
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+** AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+** IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+** FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+** DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+** CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+** OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+*****************************************************************************
+*/
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+/* Specify the memory areas */
+MEMORY
+{
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 192K
+CCMRAM (xrw)      : ORIGIN = 0x10000000, LENGTH = 64K
+FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 2048K
+}
+
+/* Highest address of the user mode stack */
+_estack = ORIGIN(RAM) + LENGTH(RAM);    /* end of RAM */
+/* Generate a link error if heap and stack don't fit into RAM */
+_Min_Heap_Size = 0x200;      /* required amount of heap  */
+_Min_Stack_Size = 0x400; /* required amount of stack */
+
+/* Define output sections */
+SECTIONS
+{
+  /* The startup code goes first into FLASH */
+  .isr_vector :
+  {
+    . = ALIGN(4);
+    KEEP(*(.isr_vector)) /* Startup code */
+    . = ALIGN(4);
+  } >FLASH
+
+  /* The program code and other data goes into FLASH */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)           /* .text sections (code) */
+    *(.text*)          /* .text* sections (code) */
+    *(.glue_7)         /* glue arm to thumb code */
+    *(.glue_7t)        /* glue thumb to arm code */
+    *(.eh_frame)
+
+    KEEP (*(.init))
+    KEEP (*(.fini))
+
+    . = ALIGN(4);
+    _etext = .;        /* define a global symbols at end of code */
+  } >FLASH
+
+  /* Constant data goes into FLASH */
+  .rodata :
+  {
+    . = ALIGN(4);
+    *(.rodata)         /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
+    . = ALIGN(4);
+  } >FLASH
+
+  .ARM.extab (READONLY) : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  {
+    . = ALIGN(4);
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+    . = ALIGN(4);
+  } >FLASH
+
+  .ARM (READONLY) : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  {
+    . = ALIGN(4);
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+    . = ALIGN(4);
+  } >FLASH
+
+  .preinit_array (READONLY) : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  {
+    . = ALIGN(4);
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+    . = ALIGN(4);
+  } >FLASH
+
+  .init_array (READONLY) : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  {
+    . = ALIGN(4);
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+    . = ALIGN(4);
+  } >FLASH
+
+  .fini_array (READONLY) : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  {
+    . = ALIGN(4);
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+    . = ALIGN(4);
+  } >FLASH
+
+  _siccmram = LOADADDR(.ccmram);
+
+  /* CCM-RAM section
+  *
+  * IMPORTANT NOTE!
+  * If initialized variables will be placed in this section,
+  * the startup code needs to be modified to copy the init-values.
+  */
+  .ccmram :
+  {
+    . = ALIGN(4);
+    _sccmram = .;       /* create a global symbol at ccmram start */
+    *(.ccmram)
+    *(.ccmram*)
+
+    . = ALIGN(4);
+    _eccmram = .;       /* create a global symbol at ccmram end */
+  } >CCMRAM AT> FLASH
+
+  /* used by the startup to initialize data */
+  _sidata = LOADADDR(.data);
+
+  /* Initialized data sections goes into RAM, load LMA copy after code */
+  .data :
+  {
+    . = ALIGN(4);
+    _sdata = .;        /* create a global symbol at data start */
+    *(.data)           /* .data sections */
+    *(.data*)          /* .data* sections */
+    *(.RamFunc)        /* .RamFunc sections */
+    *(.RamFunc*)       /* .RamFunc* sections */
+
+    . = ALIGN(4);
+  } >RAM AT> FLASH
+
+ /* Initialized TLS data section */
+  .tdata : ALIGN(4)
+  {
+    *(.tdata .tdata.* .gnu.linkonce.td.*)
+    . = ALIGN(4);
+    _edata = .;        /* define a global symbol at data end */
+    PROVIDE(__data_end = .);
+    PROVIDE(__tdata_end = .);
+  } >RAM AT> FLASH
+
+  PROVIDE( __tdata_start = ADDR(.tdata) );
+  PROVIDE( __tdata_size = __tdata_end - __tdata_start );
+
+  PROVIDE( __data_start = ADDR(.data) );
+  PROVIDE( __data_size = __data_end - __data_start );
+
+  PROVIDE( __tdata_source = LOADADDR(.tdata) );
+  PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+  PROVIDE( __tdata_source_size = __tdata_source_end - __tdata_source );
+
+  PROVIDE( __data_source = LOADADDR(.data) );
+  PROVIDE( __data_source_end = __tdata_source_end );
+  PROVIDE( __data_source_size = __data_source_end - __data_source );
+  /* Uninitialized data section */
+  .tbss (NOLOAD) : ALIGN(4)
+  {
+     /* This is used by the startup in order to initialize the .bss secion */
+    _sbss = .;         /* define a global symbol at bss start */
+    __bss_start__ = _sbss;
+    *(.tbss .tbss.*)
+    . = ALIGN(4);
+    PROVIDE( __tbss_end = . );
+  } >RAM
+
+  PROVIDE( __tbss_start = ADDR(.tbss) );
+  PROVIDE( __tbss_size = __tbss_end - __tbss_start );
+  PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+
+  PROVIDE( __tls_base = __tdata_start );
+  PROVIDE( __tls_end = __tbss_end );
+  PROVIDE( __tls_size = __tls_end - __tls_base );
+  PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+  PROVIDE( __tls_size_align = (__tls_size + __tls_align - 1) & ~(__tls_align - 1) );
+  PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+  PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+  .bss (NOLOAD) : ALIGN(4)
+  {
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+
+      . = ALIGN(4);
+    _ebss = .;         /* define a global symbol at bss end */
+    __bss_end__ = _ebss;
+      PROVIDE( __bss_end = .);
+  } >RAM
+  PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+
+  PROVIDE( __bss_start = __tbss_start );
+  PROVIDE( __bss_size = __bss_end - __bss_start );
+
+  /* User_heap_stack section, used to check that there is enough RAM left */
+  ._user_heap_stack (NOLOAD) :
+  {
+    . = ALIGN(8);
+    PROVIDE ( end = . );
+    PROVIDE ( _end = . );
+    . = . + _Min_Heap_Size;
+    . = . + _Min_Stack_Size;
+    . = ALIGN(8);
+  } >RAM
+
+
+
+  /* Remove information from the standard libraries */
+  /DISCARD/ :
+  {
+    libc.a:* ( * )
+    libm.a:* ( * )
+    libgcc.a:* ( * )
+  }
+
+}

--- a/example/arm-none-eabi/conanfile.txt
+++ b/example/arm-none-eabi/conanfile.txt
@@ -1,0 +1,11 @@
+[requires]
+fmt/9.1.0
+
+[layout]
+cmake_layout
+
+[generators]
+CMakeDeps
+
+
+[options]

--- a/example/arm-none-eabi/fmt_dummy.cpp
+++ b/example/arm-none-eabi/fmt_dummy.cpp
@@ -1,0 +1,13 @@
+#include "fmt_dummy.h"
+
+#include <fmt/format.h>
+
+void callFmt()
+{
+    const std::string str = fmt::format("Int format {}", 42);
+
+    if (str.empty() || strF.empty())
+    {
+
+    }
+}

--- a/example/arm-none-eabi/fmt_dummy.h
+++ b/example/arm-none-eabi/fmt_dummy.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    void callFmt();
+
+#ifdef __cplusplus
+}
+#endif

--- a/example/arm-none-eabi/gcc-arm-none-eabi.cmake
+++ b/example/arm-none-eabi/gcc-arm-none-eabi.cmake
@@ -1,0 +1,289 @@
+﻿include_guard()
+
+
+
+#[[
+    This function downloads a selected compiler to a predefined directory.
+    Some archives (like tar.xz) need to be flattend first
+    This fuction ensures that the files located at the EXTRACT_TO folder contain the necessarry bin files
+
+    COMPILER_URL= https://developer.arm.com/-/media/Files/downloads/gnu/14.3.rel1/binrel/arm-gnu-toolchain-14.3.rel1-mingw-w64-i686-arm-none-eabi.zip
+    EXTRACT_TO= ./toolchain
+]]
+function(direct_download_compiler COMPILER_URL EXTRACT_TO)
+  set(SUPPORTED_EXTENSIONS ".tar.gz" ".tar.bz2" ".tar.xz" ".tgz" ".tbz2" ".zip")
+
+  set(EXPECTED_HASH "")
+  if(ARGC GREATER 2)
+    set(EXPECTED_HASH "${ARGV2}")
+  endif()
+
+  get_filename_component(ARCHIVE_NAME "${COMPILER_URL}" NAME)
+
+  # check achive format
+  set(FOUND_FORMAT "")
+  foreach(EXT IN LISTS SUPPORTED_EXTENSIONS)
+    if(ARCHIVE_NAME MATCHES "${EXT}$")
+      set(FOUND_FORMAT "${EXT}")
+      break()
+    endif()
+  endforeach()
+
+  if(NOT FOUND_FORMAT)
+    return()
+  endif()
+
+  # target dirs
+  set(DOWNLOAD_DIR "${CMAKE_BINARY_DIR}/downloads")
+  file(MAKE_DIRECTORY "${DOWNLOAD_DIR}")
+  set(ARCHIVE_PATH "${DOWNLOAD_DIR}/${ARCHIVE_NAME}")
+
+  if(EXISTS "${EXTRACT_TO}/bin" OR EXISTS "${EXTRACT_TO}/lib")
+    message(STATUS "Compiler already extracted...: ${EXTRACT_TO}")
+    set(DIRECT_DOWNLOAD_COMPILER_BIN_DIR
+        "${EXTRACT_TO}"
+        PARENT_SCOPE)
+    return()
+  endif()
+
+  # check if download is necessarry
+  set(NEED_DOWNLOAD TRUE)
+  if(EXISTS "${ARCHIVE_PATH}")
+    if(EXPECTED_HASH)
+      file(SHA256 "${ARCHIVE_PATH}" ACTUAL_HASH)
+      if(NOT "${EXPECTED_HASH}" STREQUAL "${ACTUAL_HASH}")
+        message(
+          WARNING
+            "Hash mismatch: expected ${EXPECTED_HASH}, found ${ACTUAL_HASH}")
+        file(REMOVE "${ARCHIVE_PATH}")
+      else()
+        set(NEED_DOWNLOAD FALSE)
+        message(STATUS "found archive with valid hash: ${ARCHIVE_PATH}")
+      endif()
+    else()
+      set(NEED_DOWNLOAD FALSE)
+      message(
+        STATUS "archive already downloaded (no hash check): ${ARCHIVE_PATH}")
+    endif()
+  endif()
+
+  # Download if needed
+  if(NEED_DOWNLOAD)
+    message(STATUS "download Compiler from: ${COMPILER_URL}")
+    file(
+      DOWNLOAD "${COMPILER_URL}" "${ARCHIVE_PATH}"
+      SHOW_PROGRESS
+      STATUS DOWNLOAD_STATUS
+      TLS_VERIFY ON)
+    list(GET DOWNLOAD_STATUS 0 DOWNLOAD_RESULT)
+    if(NOT DOWNLOAD_RESULT EQUAL 0)
+      message(FATAL_ERROR "Download failed: ${COMPILER_URL}")
+    endif()
+
+    if(EXPECTED_HASH)
+      file(SHA256 "${ARCHIVE_PATH}" ACTUAL_HASH)
+      if(NOT "${EXPECTED_HASH}" STREQUAL "${ACTUAL_HASH}")
+        message(
+          FATAL_ERROR
+            "hash missmatch: expected ${EXPECTED_HASH}, found ${ACTUAL_HASH}")
+      endif()
+    endif()
+    message(STATUS "Download finnished: ${ARCHIVE_PATH}")
+  endif()
+
+  # preperare temp extraction folder
+  set(TEMP_EXTRACT_DIR "${CMAKE_BINARY_DIR}/_temp_extract_dir_${ARCHIVE_NAME}")
+  file(REMOVE_RECURSE "${TEMP_EXTRACT_DIR}")
+  file(MAKE_DIRECTORY "${TEMP_EXTRACT_DIR}")
+
+  # found archive
+  message(STATUS "Extract archive → ${TEMP_EXTRACT_DIR}")
+  file(ARCHIVE_EXTRACT INPUT "${ARCHIVE_PATH}" DESTINATION
+       "${TEMP_EXTRACT_DIR}")
+
+  # look up Top-Level-Dir in archive
+  file(
+    GLOB TOPLEVEL_ITEMS
+    RELATIVE "${TEMP_EXTRACT_DIR}"
+    "${TEMP_EXTRACT_DIR}/*")
+  list(LENGTH TOPLEVEL_ITEMS NUM_TOPLEVEL)
+
+  if(NUM_TOPLEVEL EQUAL 1)
+    list(GET TOPLEVEL_ITEMS 0 SINGLE_DIR_NAME)
+    set(SINGLE_DIR_PATH "${TEMP_EXTRACT_DIR}/${SINGLE_DIR_NAME}")
+    if(IS_DIRECTORY "${SINGLE_DIR_PATH}")
+      message(STATUS "Found Top-Level-directory: ${SINGLE_DIR_NAME}")
+      # copy content of this directory to folder EXTRACT_TO
+      file(COPY "${SINGLE_DIR_PATH}/" DESTINATION "${EXTRACT_TO}")
+    else()
+      # only a single file ....
+      file(COPY "${SINGLE_DIR_PATH}" DESTINATION "${EXTRACT_TO}")
+    endif()
+  else()
+    # multiple files/folders => copy everything
+    file(COPY "${TEMP_EXTRACT_DIR}/" DESTINATION "${EXTRACT_TO}")
+  endif()
+
+  # cleanup
+  file(REMOVE_RECURSE "${TEMP_EXTRACT_DIR}")
+
+  message(STATUS "compiler extraction done: ${EXTRACT_TO}")
+
+  set(DIRECT_DOWNLOAD_COMPILER_BIN_DIR
+      "${EXTRACT_TO}"
+      PARENT_SCOPE)
+endfunction()
+
+
+
+
+# --- Detect host platform (for optional logging or filters) ---
+string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" HOST_OS)
+set(HOST_ARCH "${CMAKE_HOST_SYSTEM_PROCESSOR}")
+
+if(HOST_OS STREQUAL "windows")
+  set(HOST_TAG "windows")
+elseif(HOST_OS STREQUAL "darwin")
+  set(HOST_TAG "mac")
+elseif(HOST_OS STREQUAL "linux")
+  set(HOST_TAG "linux")
+else()
+  set(HOST_TAG "${HOST_OS}")
+endif()
+
+message(STATUS "Host platform detected: ${HOST_TAG} (${HOST_ARCH})")
+# --- Determine toolchain installation path ---
+
+set(TOOLCHAIN_PATH "${PROJECT_BINARY_DIR}/gcc_arm_none_eabi")
+
+
+if(NOT EXISTS ${TOOLCHAIN_PATH})
+  message(STATUS "About to download Compiler since TOOLCHAIN_PATH = ${TOOLCHAIN_PATH} does not exist")
+  direct_download_compiler("${TOOLCHAIN_URL}" "${TOOLCHAIN_PATH}")
+endif()
+
+set(EXPECTED_COMPILER_TRIPLET "arm-none-eabi")
+set(TOOLCHAIN_BIN_DIR "${TOOLCHAIN_PATH}/bin")
+
+# --- Extend system PATH to include toolchain binaries ---
+if(EXISTS "${TOOLCHAIN_BIN_DIR}")
+  list(APPEND CMAKE_PROGRAM_PATH ${TOOLCHAIN_PATH} ${TOOLCHAIN_BIN_DIR})
+  message( STATUS "Toolchain bin directory added to CMAKE_PROGRAM_PATH: ${EXPECTED_TOOLCHAIN_BIN_DIR}" )
+endif()
+
+
+
+
+# --- CMake cross-compile settings ---
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR "${TOOLCHAIN_TARGET}")
+# --- Determine executable suffix on Windows ---
+if(WIN32)
+  set(TOOL_SUFFIX ".exe")
+else()
+  set(TOOL_SUFFIX "")
+endif()
+
+# --- Set tool paths with suffix ---
+
+if(EXISTS ${TOOLCHAIN_BIN_DIR})
+  set(CMAKE_C_COMPILER "${TOOLCHAIN_BIN_DIR}/${EXPECTED_COMPILER_TRIPLET}-gcc${TOOL_SUFFIX}")
+  set(CMAKE_CXX_COMPILER "${TOOLCHAIN_BIN_DIR}/${EXPECTED_COMPILER_TRIPLET}-g++${TOOL_SUFFIX}")
+  set(CMAKE_ASM_COMPILER "${TOOLCHAIN_BIN_DIR}/${EXPECTED_COMPILER_TRIPLET}-gcc${TOOL_SUFFIX}")
+  set(CMAKE_AR "${TOOLCHAIN_BIN_DIR}/${EXPECTED_COMPILER_TRIPLET}-ar${TOOL_SUFFIX}")
+  set(CMAKE_OBJCOPY "${TOOLCHAIN_BIN_DIR}/${EXPECTED_COMPILER_TRIPLET}-objcopy${TOOL_SUFFIX}")
+  set(CMAKE_OBJDUMP "${TOOLCHAIN_BIN_DIR}/${EXPECTED_COMPILER_TRIPLET}-objdump${TOOL_SUFFIX}")
+  set(CMAKE_SIZE "${TOOLCHAIN_BIN_DIR}/${EXPECTED_COMPILER_TRIPLET}-size${TOOL_SUFFIX}")
+  set(CMAKE_STRIP "${TOOLCHAIN_BIN_DIR}/${EXPECTED_COMPILER_TRIPLET}-strip${TOOL_SUFFIX}")
+  
+  # --- Check each tool exists and runs properly ---
+  foreach(
+    var IN
+    ITEMS CMAKE_C_COMPILER
+          CMAKE_CXX_COMPILER
+          CMAKE_ASM_COMPILER
+          CMAKE_AR
+          CMAKE_OBJCOPY
+          CMAKE_OBJDUMP
+          CMAKE_SIZE
+          CMAKE_STRIP)
+    set(tool_path "${${var}}")
+  
+    if(NOT EXISTS "${tool_path}")
+      message(FATAL_ERROR "Tool ${var} not found at path: ${tool_path}")
+    endif()
+  
+    # Run '<tool> --version' to verify it works
+    execute_process(
+      COMMAND "${tool_path}" --version
+      RESULT_VARIABLE res
+      OUTPUT_QUIET ERROR_QUIET)
+  
+    if(NOT res EQUAL 0)
+      message(
+        FATAL_ERROR
+          "Tool ${var} at ${tool_path} failed to run '--version'. Result: ${res}")
+    endif()
+  endforeach()
+  
+  # --- Cache tool paths ---
+  foreach(
+    var IN
+    ITEMS CMAKE_C_COMPILER
+          CMAKE_CXX_COMPILER
+          CMAKE_ASM_COMPILER
+          CMAKE_AR
+          CMAKE_OBJCOPY
+          CMAKE_OBJDUMP
+          CMAKE_SIZE
+          CMAKE_STRIP)
+    set(${var}
+        "${${var}}"
+        CACHE FILEPATH "Toolchain tool: ${var}")
+  endforeach()
+endif()
+
+# Perform compiler test with the static library
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+# --- Apply user-provided compiler arch flags ---
+
+message(STATUS "Compiler architecture flags: ${COMPILER_ARCH_FLAGS}")
+
+# Add classic optimization flags for embedded
+set(COMMON_OPT_FLAGS "-ffunction-sections -fdata-sections")
+
+# Compiler flags
+set(CMAKE_C_FLAGS "${COMPILER_ARCH_FLAGS} ${COMMON_OPT_FLAGS}" CACHE STRING "C compiler arch flags")
+set(CMAKE_CXX_FLAGS "${COMPILER_ARCH_FLAGS} ${COMMON_OPT_FLAGS}"  CACHE STRING "C++ compiler arch flags")
+set(CMAKE_ASM_FLAGS  "${COMPILER_ARCH_FLAGS}"  CACHE STRING "ASM compiler arch flags")
+
+# Linker flag for garbage collecting unused sections
+set(CMAKE_EXE_LINKER_FLAGS  "-Wl,--gc-sections -ffunction-sections -fdata-sections"  CACHE STRING "Linker flags for executable" FORCE)
+
+# Basis-Architektur-Flags
+set(CMAKE_C_FLAGS  "${COMPILER_ARCH_FLAGS}"  CACHE STRING "C compiler arch flags" FORCE)
+set(CMAKE_CXX_FLAGS "${COMPILER_ARCH_FLAGS}" CACHE STRING "C++ compiler arch flags" FORCE)
+
+# Debug-Build: Optimierung aus + Debug-Symbole
+set(CMAKE_C_FLAGS_DEBUG "-Og -g" CACHE STRING "C Debug flags" FORCE)
+set(CMAKE_CXX_FLAGS_DEBUG "-Og -g" CACHE STRING "C++ Debug flags" FORCE)
+
+# Release-Build: Optimiert für Geschwindigkeit, keine Debug-Symbole
+set(CMAKE_C_FLAGS_RELEASE "-Os" CACHE STRING "C Release flags" FORCE)
+set(CMAKE_CXX_FLAGS_RELEASE "-Os" CACHE STRING "C++ Release flags" FORCE)
+
+# RelWithDebInfo: Optimiert, aber mit Debug-Symbolen (z.B. -O2 + -g)
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g" CACHE STRING "C Release with Debug Info flags" FORCE)
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g" CACHE STRING "C++ Release with Debug Info flags" FORCE)
+
+# MinSizeRel: Minimale Größe (üblich: -Os, manchmal -Oz falls unterstützt)
+set(CMAKE_C_FLAGS_MINSIZEREL "-Os" CACHE STRING "C Min Size Release flags" FORCE)
+set(CMAKE_CXX_FLAGS_MINSIZEREL  "-Os"  CACHE STRING "C++ Min Size Release flags" FORCE)
+
+# Build-Type-spezifische Ergänzungen, angehängt an die Basis-Flags optionally
+# use -g3 for more debug infos than -g
+set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS} -g" CACHE STRING "Linker flags for Debug build" FORCE)
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS} -g0" CACHE STRING "Linker flags for Release build" FORCE)
+set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS} -g" CACHE STRING "Linker flags for RelWithDebInfo build" FORCE)
+set(CMAKE_EXE_LINKER_FLAGS_MINSIZEREL "${CMAKE_EXE_LINKER_FLAGS} -g0" CACHE STRING "Linker flags for MinSizeRel build" FORCE)

--- a/example/arm-none-eabi/main.c
+++ b/example/arm-none-eabi/main.c
@@ -1,0 +1,20 @@
+
+#include "syscall_wrapper.h"
+
+int main();
+
+#define ARRAY_SIZE 12
+
+
+
+void SystemInit()
+{
+
+}
+
+int main()
+{
+
+
+  return 0;
+}

--- a/example/arm-none-eabi/startup_stm32f429xx.s
+++ b/example/arm-none-eabi/startup_stm32f429xx.s
@@ -1,0 +1,543 @@
+/**
+  ******************************************************************************
+  * @file      startup_stm32f429xx.s
+  * @author    MCD Application Team
+  * @brief     STM32F429xx Devices vector table for GCC based toolchains. 
+  *            This module performs:
+  *                - Set the initial SP
+  *                - Set the initial PC == Reset_Handler,
+  *                - Set the vector table entries with the exceptions ISR address
+  *                - Branches to main in the C library (which eventually
+  *                  calls main()).
+  *            After Reset the Cortex-M4 processor is in Thread mode,
+  *            priority is Privileged, and the Stack is set to Main.
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+    
+  .syntax unified
+  .cpu cortex-m4
+  .fpu softvfp
+  .thumb
+
+.global  g_pfnVectors
+.global  Default_Handler
+
+/* start address for the initialization values of the .data section. 
+defined in linker script */
+.word  _sidata
+/* start address for the .data section. defined in linker script */  
+.word  _sdata
+/* end address for the .data section. defined in linker script */
+.word  _edata
+/* start address for the .bss section. defined in linker script */
+.word  _sbss
+/* end address for the .bss section. defined in linker script */
+.word  _ebss
+/* stack used for SystemInit_ExtMemCtl; always internal RAM used */
+
+/**
+ * @brief  This is the code that gets called when the processor first
+ *          starts execution following a reset event. Only the absolutely
+ *          necessary set is performed, after which the application
+ *          supplied main() routine is called. 
+ * @param  None
+ * @retval : None
+*/
+
+    .section  .text.Reset_Handler
+  .weak  Reset_Handler
+  .type  Reset_Handler, %function
+Reset_Handler: 
+  ldr   sp, =_estack       /* set stack pointer */
+
+/* Call the clock system initialization function.*/
+  bl  SystemInit   
+ 
+/* Copy the data segment initializers from flash to SRAM */  
+  ldr r0, =_sdata
+  ldr r1, =_edata
+  ldr r2, =_sidata
+  movs r3, #0
+  b LoopCopyDataInit
+
+CopyDataInit:
+  ldr r4, [r2, r3]
+  str r4, [r0, r3]
+  adds r3, r3, #4
+
+LoopCopyDataInit:
+  adds r4, r0, r3
+  cmp r4, r1
+  bcc CopyDataInit
+  
+/* Zero fill the bss segment. */
+  ldr r2, =_sbss
+  ldr r4, =_ebss
+  movs r3, #0
+  b LoopFillZerobss
+
+FillZerobss:
+  str  r3, [r2]
+  adds r2, r2, #4
+
+LoopFillZerobss:
+  cmp r2, r4
+  bcc FillZerobss
+  
+/* Call static constructors */
+    bl __libc_init_array
+/* Call the application's entry point.*/
+  bl  main
+  bx  lr    
+.size  Reset_Handler, .-Reset_Handler
+
+/**
+ * @brief  This is the code that gets called when the processor receives an 
+ *         unexpected interrupt.  This simply enters an infinite loop, preserving
+ *         the system state for examination by a debugger.
+ * @param  None     
+ * @retval None       
+*/
+    .section  .text.Default_Handler,"ax",%progbits
+Default_Handler:
+Infinite_Loop:
+  b  Infinite_Loop
+  .size  Default_Handler, .-Default_Handler
+/******************************************************************************
+*
+* The minimal vector table for a Cortex M3. Note that the proper constructs
+* must be placed on this to ensure that it ends up at physical address
+* 0x0000.0000.
+* 
+*******************************************************************************/
+   .section  .isr_vector,"a",%progbits
+  .type  g_pfnVectors, %object
+   
+g_pfnVectors:
+  .word  _estack
+  .word  Reset_Handler
+
+  .word  NMI_Handler
+  .word  HardFault_Handler
+  .word  MemManage_Handler
+  .word  BusFault_Handler
+  .word  UsageFault_Handler
+  .word  0
+  .word  0
+  .word  0
+  .word  0
+  .word  SVC_Handler
+  .word  DebugMon_Handler
+  .word  0
+  .word  PendSV_Handler
+  .word  SysTick_Handler
+  
+  /* External Interrupts */
+  .word     WWDG_IRQHandler                   /* Window WatchDog              */                                        
+  .word     PVD_IRQHandler                    /* PVD through EXTI Line detection */                        
+  .word     TAMP_STAMP_IRQHandler             /* Tamper and TimeStamps through the EXTI line */            
+  .word     RTC_WKUP_IRQHandler               /* RTC Wakeup through the EXTI line */                      
+  .word     FLASH_IRQHandler                  /* FLASH                        */                                          
+  .word     RCC_IRQHandler                    /* RCC                          */                                            
+  .word     EXTI0_IRQHandler                  /* EXTI Line0                   */                        
+  .word     EXTI1_IRQHandler                  /* EXTI Line1                   */                          
+  .word     EXTI2_IRQHandler                  /* EXTI Line2                   */                          
+  .word     EXTI3_IRQHandler                  /* EXTI Line3                   */                          
+  .word     EXTI4_IRQHandler                  /* EXTI Line4                   */                          
+  .word     DMA1_Stream0_IRQHandler           /* DMA1 Stream 0                */                  
+  .word     DMA1_Stream1_IRQHandler           /* DMA1 Stream 1                */                   
+  .word     DMA1_Stream2_IRQHandler           /* DMA1 Stream 2                */                   
+  .word     DMA1_Stream3_IRQHandler           /* DMA1 Stream 3                */                   
+  .word     DMA1_Stream4_IRQHandler           /* DMA1 Stream 4                */                   
+  .word     DMA1_Stream5_IRQHandler           /* DMA1 Stream 5                */                   
+  .word     DMA1_Stream6_IRQHandler           /* DMA1 Stream 6                */                   
+  .word     ADC_IRQHandler                    /* ADC1, ADC2 and ADC3s         */                   
+  .word     CAN1_TX_IRQHandler                /* CAN1 TX                      */                         
+  .word     CAN1_RX0_IRQHandler               /* CAN1 RX0                     */                          
+  .word     CAN1_RX1_IRQHandler               /* CAN1 RX1                     */                          
+  .word     CAN1_SCE_IRQHandler               /* CAN1 SCE                     */                          
+  .word     EXTI9_5_IRQHandler                /* External Line[9:5]s          */                          
+  .word     TIM1_BRK_TIM9_IRQHandler          /* TIM1 Break and TIM9          */         
+  .word     TIM1_UP_TIM10_IRQHandler          /* TIM1 Update and TIM10        */         
+  .word     TIM1_TRG_COM_TIM11_IRQHandler     /* TIM1 Trigger and Commutation and TIM11 */
+  .word     TIM1_CC_IRQHandler                /* TIM1 Capture Compare         */                          
+  .word     TIM2_IRQHandler                   /* TIM2                         */                   
+  .word     TIM3_IRQHandler                   /* TIM3                         */                   
+  .word     TIM4_IRQHandler                   /* TIM4                         */                   
+  .word     I2C1_EV_IRQHandler                /* I2C1 Event                   */                          
+  .word     I2C1_ER_IRQHandler                /* I2C1 Error                   */                          
+  .word     I2C2_EV_IRQHandler                /* I2C2 Event                   */                          
+  .word     I2C2_ER_IRQHandler                /* I2C2 Error                   */                            
+  .word     SPI1_IRQHandler                   /* SPI1                         */                   
+  .word     SPI2_IRQHandler                   /* SPI2                         */                   
+  .word     USART1_IRQHandler                 /* USART1                       */                   
+  .word     USART2_IRQHandler                 /* USART2                       */                   
+  .word     USART3_IRQHandler                 /* USART3                       */                   
+  .word     EXTI15_10_IRQHandler              /* External Line[15:10]s        */                          
+  .word     RTC_Alarm_IRQHandler              /* RTC Alarm (A and B) through EXTI Line */                 
+  .word     OTG_FS_WKUP_IRQHandler            /* USB OTG FS Wakeup through EXTI line */                       
+  .word     TIM8_BRK_TIM12_IRQHandler         /* TIM8 Break and TIM12         */         
+  .word     TIM8_UP_TIM13_IRQHandler          /* TIM8 Update and TIM13        */         
+  .word     TIM8_TRG_COM_TIM14_IRQHandler     /* TIM8 Trigger and Commutation and TIM14 */
+  .word     TIM8_CC_IRQHandler                /* TIM8 Capture Compare         */                          
+  .word     DMA1_Stream7_IRQHandler           /* DMA1 Stream7                 */                          
+  .word     FMC_IRQHandler                    /* FMC                         */                   
+  .word     SDIO_IRQHandler                   /* SDIO                         */                   
+  .word     TIM5_IRQHandler                   /* TIM5                         */                   
+  .word     SPI3_IRQHandler                   /* SPI3                         */                   
+  .word     UART4_IRQHandler                  /* UART4                        */                   
+  .word     UART5_IRQHandler                  /* UART5                        */                   
+  .word     TIM6_DAC_IRQHandler               /* TIM6 and DAC1&2 underrun errors */                   
+  .word     TIM7_IRQHandler                   /* TIM7                         */
+  .word     DMA2_Stream0_IRQHandler           /* DMA2 Stream 0                */                   
+  .word     DMA2_Stream1_IRQHandler           /* DMA2 Stream 1                */                   
+  .word     DMA2_Stream2_IRQHandler           /* DMA2 Stream 2                */                   
+  .word     DMA2_Stream3_IRQHandler           /* DMA2 Stream 3                */                   
+  .word     DMA2_Stream4_IRQHandler           /* DMA2 Stream 4                */                   
+  .word     ETH_IRQHandler                    /* Ethernet                     */                   
+  .word     ETH_WKUP_IRQHandler               /* Ethernet Wakeup through EXTI line */                     
+  .word     CAN2_TX_IRQHandler                /* CAN2 TX                      */                          
+  .word     CAN2_RX0_IRQHandler               /* CAN2 RX0                     */                          
+  .word     CAN2_RX1_IRQHandler               /* CAN2 RX1                     */                          
+  .word     CAN2_SCE_IRQHandler               /* CAN2 SCE                     */                          
+  .word     OTG_FS_IRQHandler                 /* USB OTG FS                   */                   
+  .word     DMA2_Stream5_IRQHandler           /* DMA2 Stream 5                */                   
+  .word     DMA2_Stream6_IRQHandler           /* DMA2 Stream 6                */                   
+  .word     DMA2_Stream7_IRQHandler           /* DMA2 Stream 7                */                   
+  .word     USART6_IRQHandler                 /* USART6                       */                    
+  .word     I2C3_EV_IRQHandler                /* I2C3 event                   */                          
+  .word     I2C3_ER_IRQHandler                /* I2C3 error                   */                          
+  .word     OTG_HS_EP1_OUT_IRQHandler         /* USB OTG HS End Point 1 Out   */                   
+  .word     OTG_HS_EP1_IN_IRQHandler          /* USB OTG HS End Point 1 In    */                   
+  .word     OTG_HS_WKUP_IRQHandler            /* USB OTG HS Wakeup through EXTI */                         
+  .word     OTG_HS_IRQHandler                 /* USB OTG HS                   */                   
+  .word     DCMI_IRQHandler                   /* DCMI                         */                   
+  .word     0                                 /* Reserved                     */                   
+  .word     HASH_RNG_IRQHandler               /* Hash and Rng                 */
+  .word     FPU_IRQHandler                    /* FPU                          */
+  .word     UART7_IRQHandler                  /* UART7                        */      
+  .word     UART8_IRQHandler                  /* UART8                        */
+  .word     SPI4_IRQHandler                   /* SPI4                         */
+  .word     SPI5_IRQHandler                   /* SPI5 						  */
+  .word     SPI6_IRQHandler                   /* SPI6						  */
+  .word     SAI1_IRQHandler                   /* SAI1						  */
+  .word     LTDC_IRQHandler                   /* LTDC_IRQHandler			  */
+  .word     LTDC_ER_IRQHandler                /* LTDC_ER_IRQHandler			  */
+  .word     DMA2D_IRQHandler                  /* DMA2D                        */
+  
+
+  .size  g_pfnVectors, .-g_pfnVectors
+
+/*******************************************************************************
+*
+* Provide weak aliases for each Exception handler to the Default_Handler. 
+* As they are weak aliases, any function with the same name will override 
+* this definition.
+* 
+*******************************************************************************/
+   .weak      NMI_Handler
+   .thumb_set NMI_Handler,Default_Handler
+  
+   .weak      HardFault_Handler
+   .thumb_set HardFault_Handler,Default_Handler
+  
+   .weak      MemManage_Handler
+   .thumb_set MemManage_Handler,Default_Handler
+  
+   .weak      BusFault_Handler
+   .thumb_set BusFault_Handler,Default_Handler
+
+   .weak      UsageFault_Handler
+   .thumb_set UsageFault_Handler,Default_Handler
+
+   .weak      SVC_Handler
+   .thumb_set SVC_Handler,Default_Handler
+
+   .weak      DebugMon_Handler
+   .thumb_set DebugMon_Handler,Default_Handler
+
+   .weak      PendSV_Handler
+   .thumb_set PendSV_Handler,Default_Handler
+
+   .weak      SysTick_Handler
+   .thumb_set SysTick_Handler,Default_Handler              
+  
+   .weak      WWDG_IRQHandler                   
+   .thumb_set WWDG_IRQHandler,Default_Handler      
+                  
+   .weak      PVD_IRQHandler      
+   .thumb_set PVD_IRQHandler,Default_Handler
+               
+   .weak      TAMP_STAMP_IRQHandler            
+   .thumb_set TAMP_STAMP_IRQHandler,Default_Handler
+            
+   .weak      RTC_WKUP_IRQHandler                  
+   .thumb_set RTC_WKUP_IRQHandler,Default_Handler
+            
+   .weak      FLASH_IRQHandler         
+   .thumb_set FLASH_IRQHandler,Default_Handler
+                  
+   .weak      RCC_IRQHandler      
+   .thumb_set RCC_IRQHandler,Default_Handler
+                  
+   .weak      EXTI0_IRQHandler         
+   .thumb_set EXTI0_IRQHandler,Default_Handler
+                  
+   .weak      EXTI1_IRQHandler         
+   .thumb_set EXTI1_IRQHandler,Default_Handler
+                     
+   .weak      EXTI2_IRQHandler         
+   .thumb_set EXTI2_IRQHandler,Default_Handler 
+                 
+   .weak      EXTI3_IRQHandler         
+   .thumb_set EXTI3_IRQHandler,Default_Handler
+                        
+   .weak      EXTI4_IRQHandler         
+   .thumb_set EXTI4_IRQHandler,Default_Handler
+                  
+   .weak      DMA1_Stream0_IRQHandler               
+   .thumb_set DMA1_Stream0_IRQHandler,Default_Handler
+         
+   .weak      DMA1_Stream1_IRQHandler               
+   .thumb_set DMA1_Stream1_IRQHandler,Default_Handler
+                  
+   .weak      DMA1_Stream2_IRQHandler               
+   .thumb_set DMA1_Stream2_IRQHandler,Default_Handler
+                  
+   .weak      DMA1_Stream3_IRQHandler               
+   .thumb_set DMA1_Stream3_IRQHandler,Default_Handler 
+                 
+   .weak      DMA1_Stream4_IRQHandler              
+   .thumb_set DMA1_Stream4_IRQHandler,Default_Handler
+                  
+   .weak      DMA1_Stream5_IRQHandler               
+   .thumb_set DMA1_Stream5_IRQHandler,Default_Handler
+                  
+   .weak      DMA1_Stream6_IRQHandler               
+   .thumb_set DMA1_Stream6_IRQHandler,Default_Handler
+                  
+   .weak      ADC_IRQHandler      
+   .thumb_set ADC_IRQHandler,Default_Handler
+               
+   .weak      CAN1_TX_IRQHandler   
+   .thumb_set CAN1_TX_IRQHandler,Default_Handler
+            
+   .weak      CAN1_RX0_IRQHandler                  
+   .thumb_set CAN1_RX0_IRQHandler,Default_Handler
+                           
+   .weak      CAN1_RX1_IRQHandler                  
+   .thumb_set CAN1_RX1_IRQHandler,Default_Handler
+            
+   .weak      CAN1_SCE_IRQHandler                  
+   .thumb_set CAN1_SCE_IRQHandler,Default_Handler
+            
+   .weak      EXTI9_5_IRQHandler   
+   .thumb_set EXTI9_5_IRQHandler,Default_Handler
+            
+   .weak      TIM1_BRK_TIM9_IRQHandler            
+   .thumb_set TIM1_BRK_TIM9_IRQHandler,Default_Handler
+            
+   .weak      TIM1_UP_TIM10_IRQHandler            
+   .thumb_set TIM1_UP_TIM10_IRQHandler,Default_Handler
+
+   .weak      TIM1_TRG_COM_TIM11_IRQHandler      
+   .thumb_set TIM1_TRG_COM_TIM11_IRQHandler,Default_Handler
+      
+   .weak      TIM1_CC_IRQHandler   
+   .thumb_set TIM1_CC_IRQHandler,Default_Handler
+                  
+   .weak      TIM2_IRQHandler            
+   .thumb_set TIM2_IRQHandler,Default_Handler
+                  
+   .weak      TIM3_IRQHandler            
+   .thumb_set TIM3_IRQHandler,Default_Handler
+                  
+   .weak      TIM4_IRQHandler            
+   .thumb_set TIM4_IRQHandler,Default_Handler
+                  
+   .weak      I2C1_EV_IRQHandler   
+   .thumb_set I2C1_EV_IRQHandler,Default_Handler
+                     
+   .weak      I2C1_ER_IRQHandler   
+   .thumb_set I2C1_ER_IRQHandler,Default_Handler
+                     
+   .weak      I2C2_EV_IRQHandler   
+   .thumb_set I2C2_EV_IRQHandler,Default_Handler
+                  
+   .weak      I2C2_ER_IRQHandler   
+   .thumb_set I2C2_ER_IRQHandler,Default_Handler
+                           
+   .weak      SPI1_IRQHandler            
+   .thumb_set SPI1_IRQHandler,Default_Handler
+                        
+   .weak      SPI2_IRQHandler            
+   .thumb_set SPI2_IRQHandler,Default_Handler
+                  
+   .weak      USART1_IRQHandler      
+   .thumb_set USART1_IRQHandler,Default_Handler
+                     
+   .weak      USART2_IRQHandler      
+   .thumb_set USART2_IRQHandler,Default_Handler
+                     
+   .weak      USART3_IRQHandler      
+   .thumb_set USART3_IRQHandler,Default_Handler
+                  
+   .weak      EXTI15_10_IRQHandler               
+   .thumb_set EXTI15_10_IRQHandler,Default_Handler
+               
+   .weak      RTC_Alarm_IRQHandler               
+   .thumb_set RTC_Alarm_IRQHandler,Default_Handler
+            
+   .weak      OTG_FS_WKUP_IRQHandler         
+   .thumb_set OTG_FS_WKUP_IRQHandler,Default_Handler
+            
+   .weak      TIM8_BRK_TIM12_IRQHandler         
+   .thumb_set TIM8_BRK_TIM12_IRQHandler,Default_Handler
+         
+   .weak      TIM8_UP_TIM13_IRQHandler            
+   .thumb_set TIM8_UP_TIM13_IRQHandler,Default_Handler
+         
+   .weak      TIM8_TRG_COM_TIM14_IRQHandler      
+   .thumb_set TIM8_TRG_COM_TIM14_IRQHandler,Default_Handler
+      
+   .weak      TIM8_CC_IRQHandler   
+   .thumb_set TIM8_CC_IRQHandler,Default_Handler
+                  
+   .weak      DMA1_Stream7_IRQHandler               
+   .thumb_set DMA1_Stream7_IRQHandler,Default_Handler
+                     
+   .weak      FMC_IRQHandler            
+   .thumb_set FMC_IRQHandler,Default_Handler
+                     
+   .weak      SDIO_IRQHandler            
+   .thumb_set SDIO_IRQHandler,Default_Handler
+                     
+   .weak      TIM5_IRQHandler            
+   .thumb_set TIM5_IRQHandler,Default_Handler
+                     
+   .weak      SPI3_IRQHandler            
+   .thumb_set SPI3_IRQHandler,Default_Handler
+                     
+   .weak      UART4_IRQHandler         
+   .thumb_set UART4_IRQHandler,Default_Handler
+                  
+   .weak      UART5_IRQHandler         
+   .thumb_set UART5_IRQHandler,Default_Handler
+                  
+   .weak      TIM6_DAC_IRQHandler                  
+   .thumb_set TIM6_DAC_IRQHandler,Default_Handler
+               
+   .weak      TIM7_IRQHandler            
+   .thumb_set TIM7_IRQHandler,Default_Handler
+         
+   .weak      DMA2_Stream0_IRQHandler               
+   .thumb_set DMA2_Stream0_IRQHandler,Default_Handler
+               
+   .weak      DMA2_Stream1_IRQHandler               
+   .thumb_set DMA2_Stream1_IRQHandler,Default_Handler
+                  
+   .weak      DMA2_Stream2_IRQHandler               
+   .thumb_set DMA2_Stream2_IRQHandler,Default_Handler
+            
+   .weak      DMA2_Stream3_IRQHandler               
+   .thumb_set DMA2_Stream3_IRQHandler,Default_Handler
+            
+   .weak      DMA2_Stream4_IRQHandler               
+   .thumb_set DMA2_Stream4_IRQHandler,Default_Handler
+   
+   .weak      ETH_IRQHandler               
+   .thumb_set ETH_IRQHandler,Default_Handler
+
+   .weak      ETH_WKUP_IRQHandler               
+   .thumb_set ETH_WKUP_IRQHandler,Default_Handler
+
+   .weak      CAN2_TX_IRQHandler   
+   .thumb_set CAN2_TX_IRQHandler,Default_Handler
+                           
+   .weak      CAN2_RX0_IRQHandler                  
+   .thumb_set CAN2_RX0_IRQHandler,Default_Handler
+                           
+   .weak      CAN2_RX1_IRQHandler                  
+   .thumb_set CAN2_RX1_IRQHandler,Default_Handler
+                           
+   .weak      CAN2_SCE_IRQHandler                  
+   .thumb_set CAN2_SCE_IRQHandler,Default_Handler
+                           
+   .weak      OTG_FS_IRQHandler      
+   .thumb_set OTG_FS_IRQHandler,Default_Handler
+                     
+   .weak      DMA2_Stream5_IRQHandler               
+   .thumb_set DMA2_Stream5_IRQHandler,Default_Handler
+                  
+   .weak      DMA2_Stream6_IRQHandler               
+   .thumb_set DMA2_Stream6_IRQHandler,Default_Handler
+                  
+   .weak      DMA2_Stream7_IRQHandler               
+   .thumb_set DMA2_Stream7_IRQHandler,Default_Handler
+                  
+   .weak      USART6_IRQHandler      
+   .thumb_set USART6_IRQHandler,Default_Handler
+                        
+   .weak      I2C3_EV_IRQHandler   
+   .thumb_set I2C3_EV_IRQHandler,Default_Handler
+                        
+   .weak      I2C3_ER_IRQHandler   
+   .thumb_set I2C3_ER_IRQHandler,Default_Handler
+                        
+   .weak      OTG_HS_EP1_OUT_IRQHandler         
+   .thumb_set OTG_HS_EP1_OUT_IRQHandler,Default_Handler
+               
+   .weak      OTG_HS_EP1_IN_IRQHandler            
+   .thumb_set OTG_HS_EP1_IN_IRQHandler,Default_Handler
+               
+   .weak      OTG_HS_WKUP_IRQHandler         
+   .thumb_set OTG_HS_WKUP_IRQHandler,Default_Handler
+            
+   .weak      OTG_HS_IRQHandler      
+   .thumb_set OTG_HS_IRQHandler,Default_Handler
+                  
+   .weak      DCMI_IRQHandler            
+   .thumb_set DCMI_IRQHandler,Default_Handler
+                                   
+   .weak      HASH_RNG_IRQHandler                  
+   .thumb_set HASH_RNG_IRQHandler,Default_Handler   
+
+   .weak      FPU_IRQHandler                  
+   .thumb_set FPU_IRQHandler,Default_Handler  
+
+   .weak      UART7_IRQHandler            
+   .thumb_set UART7_IRQHandler,Default_Handler
+
+   .weak      UART8_IRQHandler            
+   .thumb_set UART8_IRQHandler,Default_Handler
+
+   .weak      SPI4_IRQHandler            
+   .thumb_set SPI4_IRQHandler,Default_Handler
+
+   .weak      SPI5_IRQHandler            
+   .thumb_set SPI5_IRQHandler,Default_Handler
+
+   .weak      SPI6_IRQHandler            
+   .thumb_set SPI6_IRQHandler,Default_Handler
+
+   .weak      SAI1_IRQHandler            
+   .thumb_set SAI1_IRQHandler,Default_Handler
+
+   .weak      LTDC_IRQHandler            
+   .thumb_set LTDC_IRQHandler,Default_Handler
+
+   .weak      LTDC_ER_IRQHandler            
+   .thumb_set LTDC_ER_IRQHandler,Default_Handler
+
+   .weak      DMA2D_IRQHandler            
+   .thumb_set DMA2D_IRQHandler,Default_Handler

--- a/example/arm-none-eabi/stm32f407.icf
+++ b/example/arm-none-eabi/stm32f407.icf
@@ -1,0 +1,23 @@
+﻿// linker/stm32f407xx.icf
+
+// Stack und Heap Größen
+define symbol __ICFEDIT_size_cstack__ = 0x00000400;  // 1 KiB
+define symbol __ICFEDIT_size_heap__   = 0x00000200;  // 512 B
+define symbol __ICFEDIT_region_STACK_top = 0x20020000;
+
+
+// Flash-Region (ROM)
+define memory mem with size = 4G;
+define region ROM_region = mem:[from 0x08000000 to 0x080FFFFF];  // 1 MiB Flash
+define region RAM_region = mem:[from 0x20000000 to 0x2001FFFF];  // 128 KiB SRAM
+
+// Stack-Top: oberstes Ende des RAMs
+define symbol __ICFEDIT_region_STACK_top = 0x20020000;
+
+// Platzierung der Sektionen
+initialize by copy { readwrite };  // .data wird aus Flash in RAM kopiert
+do not initialize { section .noinit };  // .noinit bleibt unberührt
+
+place at address mem:0x08000000 { readonly };     // z. B. .isr_vector
+place in ROM_region { readonly };                // .text, .rodata, etc.
+place in RAM_region { readwrite, block CSTACK, block HEAP };

--- a/example/arm-none-eabi/syscall_wrapper.c
+++ b/example/arm-none-eabi/syscall_wrapper.c
@@ -1,0 +1,97 @@
+#include "syscall_wrapper.h"
+
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <stdint.h>
+#include <errno.h>
+#include <sys/types.h>
+
+
+// Symbol vom Linker
+extern uint8_t _end;  // muss im Linkerskript vorhanden sein!
+static uint8_t* heap_end = &_end;
+
+void* __wrap_malloc(size_t size) {
+    printf("[WRAP] malloc(%zu)\n", size);
+    return NULL;
+}
+
+void __wrap_free(void* ptr) {
+    printf("[WRAP] free(%p)\n", ptr);
+    
+}
+
+void* __wrap_calloc(size_t nmemb, size_t size) {
+    printf("[WRAP] calloc(%zu, %zu)\n", nmemb, size);
+    return NULL;
+}
+
+void* __wrap_realloc(void* ptr, size_t size) {
+    printf("[WRAP] realloc(%p, %zu)\n", ptr, size);
+    return NULL;
+}
+
+
+
+
+void* _sbrk(ptrdiff_t incr) {
+    uint8_t* prev_heap_end = heap_end;
+    heap_end += incr;
+    printf("[SYSCALL] _sbrk(%ld) = %p\n", (long)incr, prev_heap_end);
+    return (void*)prev_heap_end;
+}
+
+int _close(int fd) {
+    printf("[SYSCALL] _close(%d)\n", fd);
+    return -1;
+}
+
+int _fstat(int fd, struct stat* st) {
+    printf("[SYSCALL] _fstat(%d)\n", fd);
+    st->st_mode = S_IFCHR;  // Char device
+    return 0;
+}
+
+int _isatty(int fd) {
+    printf("[SYSCALL] _isatty(%d)\n", fd);
+    return 1;
+}
+
+off_t _lseek(int fd, off_t offset, int whence) {
+    printf("[SYSCALL] _lseek(%d, %ld, %d)\n", fd, (long)offset, whence);
+    return 0;
+}
+
+size_t _read(int fd, void* buf, size_t count) {
+    printf("[SYSCALL] _read(%d, %p, %zu)\n", fd, buf, count);
+    return 0;
+}
+
+size_t _write(int fd, const void* buf, size_t count) {
+    const char* cbuf = (const char*)buf;
+    printf("[SYSCALL] _write(%d, %p, %zu): \"", fd, buf, count);
+    for (size_t i = 0; i < count; ++i) {
+        putchar(cbuf[i]);
+    }
+    printf("\"\n");
+    return count;
+}
+
+int _kill(int pid, int sig) {
+    printf("[SYSCALL] _kill(%d, %d)\n", pid, sig);
+    errno = EINVAL;
+    return -1;
+}
+
+int _getpid(void) {
+    printf("[SYSCALL] _getpid()\n");
+    return 1;
+}
+
+void _exit(int status) {
+    printf("[SYSCALL] _exit(%d)\n", status);
+    while (1) {}  // Endlosschleife statt Exit
+}

--- a/example/arm-none-eabi/syscall_wrapper.h
+++ b/example/arm-none-eabi/syscall_wrapper.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <stddef.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    void* __wrap_malloc(size_t size);
+
+    void __wrap_free(void* ptr);
+
+    void* __wrap_calloc(size_t nmemb, size_t size);
+
+    void* __wrap_realloc(void* ptr, size_t size);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
I have tested this wrapper on cross arm_none_eabi builds with windows.
Turns out it failed because conan was ignoring my toolchain file and letting cmake guess compiler arguments which made my cross arm none eabi build fail.


=> Test if the user has set CMAKE_TOOLCHAIN_FILE via CLI or via preset. If this is set pass this to conan