### PR TITLE
use CMAKE_CONFIGURATION_TYPES instead of explicitly defining some

### DIFF
--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -304,7 +304,7 @@ endfunction()
 
 
 function(detect_build_type build_type)
-    get_property(multiconfig_generator GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+    get_property(multiconfig_generator GLOBAL PROPERTY )
     if(NOT multiconfig_generator)
         # Only set when we know we are in a single-configuration generator
         # Note: we may want to fail early if `CMAKE_BUILD_TYPE` is not defined
@@ -606,7 +606,8 @@ macro(conan_provide_dependency method package_name)
         else()
             # No configuration overrides, provide sensible defaults            
             if(_multiconfig_generator)
-                set(_build_configs Release Debug)
+                # use specified CMAKE_CONFIGURATION_TYPES otherwhise downstream tools may run into problems
+                set(_build_configs ${CMAKE_CONFIGURATION_TYPES})
             else()
                 set(_build_configs ${CMAKE_BUILD_TYPE})
             endif()

--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -304,7 +304,7 @@ endfunction()
 
 
 function(detect_build_type build_type)
-    get_property(multiconfig_generator GLOBAL PROPERTY )
+    get_property(multiconfig_generator GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
     if(NOT multiconfig_generator)
         # Only set when we know we are in a single-configuration generator
         # Note: we may want to fail early if `CMAKE_BUILD_TYPE` is not defined


### PR DESCRIPTION
I started using this wrapper.
In Our CMake project we are using quite a big list of compilers and additional tools.

Some of these tools (like clang-tidy) rely on a correct (cmake generated) compile_commands.json.
Since this wrapper only invokes conan for debug and release the generated compile_commands.json is malformed which breaks external tools like clang_tidy.

It's fine to exclude unneeded configs for example by overwriting the CMAKE_CONFIGURATION_TYPES list or specifying CONAN_INSTALL_BUILD_CONFIGURATIONS but this should not be done be default.