### PR TITLE
Support CMAKE_MAP_IMPORTED_CONFIG_<CONFIG> in detect_build_type

### DIFF
--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -312,6 +312,15 @@ function(detect_build_type build_type)
     if(NOT multiconfig_generator)
         # Only set when we know we are in a single-configuration generator
         # Note: we may want to fail early if `CMAKE_BUILD_TYPE` is not defined
+        # Also: If CMAKE_MAP_IMPORTED_CONFIG_<CONFIG> is set, use its value
+        # as the Conan build type instead of the current CMake build type, see also:
+        # https://cmake.org/cmake/help/latest/prop_tgt/MAP_IMPORTED_CONFIG_CONFIG.html#map-imported-config-config
+        string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_UPPER)
+        if(CMAKE_MAP_IMPORTED_CONFIG_${CMAKE_BUILD_TYPE_UPPER})
+            set(${BUILD_TYPE} ${CMAKE_MAP_IMPORTED_CONFIG_${CMAKE_BUILD_TYPE_UPPER}} PARENT_SCOPE)
+        else()
+            set(${BUILD_TYPE} ${CMAKE_BUILD_TYPE} PARENT_SCOPE)
+        endif()
         set(${build_type} ${CMAKE_BUILD_TYPE} PARENT_SCOPE)
     endif()
 endfunction()

--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -620,9 +620,15 @@ macro(conan_provide_dependency method package_name)
             if(_multiconfig_generator)
                 set(_build_configs Release Debug)
             else()
-                set(_build_configs ${CMAKE_BUILD_TYPE})
+                # Check if Conan dependencies should be build with a different build type
+                # defined by variable CMAKE_MAP_IMPORTED_CONFIG_<CMAKE_BUILD_TYPE>
+                string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_UPPER)
+                if(CMAKE_MAP_IMPORTED_CONFIG_${CMAKE_BUILD_TYPE_UPPER})
+                    set(_build_configs ${CMAKE_MAP_IMPORTED_CONFIG_${CMAKE_BUILD_TYPE_UPPER}})
+                else()
+                    set(_build_configs ${CMAKE_BUILD_TYPE})
+                endif()
             endif()
-            
         endif()
 
         list(JOIN _build_configs ", " _build_configs_msg)


### PR DESCRIPTION
Essentially, as title says. 

In CMake, [CMAKE_MAP_IMPORTED_CONFIG_<CONFIG>](https://cmake.org/cmake/help/latest/variable/CMAKE_MAP_IMPORTED_CONFIG_CONFIG.html) may be used to map custom build types (e.g. coverage) to build types/configurations known to dependencies. This could be supported as suggested in the change to the `detect_build_type` function.

Thank you for considering this.