### PR TITLE
Make `conan install` command copyable

### DIFF
--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -470,7 +470,8 @@ function(conan_install)
     set(conan_output_folder ${CMAKE_BINARY_DIR}/conan)
     # Invoke "conan install" with the provided arguments
     set(conan_args -of=${conan_output_folder})
-    message(STATUS "CMake-Conan: conan install ${CMAKE_SOURCE_DIR} ${conan_args} ${ARGN}")
+    list(JOIN ARGN " " argn_str)
+    message(STATUS "CMake-Conan: conan install ${CMAKE_SOURCE_DIR} ${conan_args} ${argn_str}")
 
 
     # In case there was not a valid cmake executable in the PATH, we inject the


### PR DESCRIPTION
Closes #729 

When ARGN contains CMake lists, those lists get expanded within quotes. This entails that the semicolons that delimit list items are printed in the log message. To make this log message reflect the actual shell command being ran, we want to strip out those semicolons. We do this by joining each list element with spaces to create a new string.