### PR TITLE
Ensure discovered CMake path is appended correctly

### DIFF
--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -478,7 +478,11 @@ function(conan_install)
     # same we used to invoke the provider to the PATH
     if(DEFINED PATH_TO_CMAKE_BIN)
         set(old_path $ENV{PATH})
-        set(ENV{PATH} "$ENV{PATH}:${PATH_TO_CMAKE_BIN}")
+        if(CMAKE_HOST_WIN32)
+            set(ENV{PATH} "$ENV{PATH};${PATH_TO_CMAKE_BIN}")
+        else()
+            set(ENV{PATH} "$ENV{PATH}:${PATH_TO_CMAKE_BIN}")
+        endif()
     endif()
 
     execute_process(COMMAND ${CONAN_COMMAND} install ${CMAKE_SOURCE_DIR} ${conan_args} ${ARGN} --format=json


### PR DESCRIPTION
When CMake is not already in the path, the directory of the `CMAKE_COMMAND` is stored into `PATH_TO_CMAKE_BIN` to append to the path. Most systems use ":" (colon) as a separator, but on windows the path needs to be separated by ";" (semicolon).

Tested that when CMake isn't in my path, it gets added correctly for:
- Windows Git-Bash terminal configuring windows build -> correctly uses windows ";" path separator
- Windows Android Studio app doing a gradle-sync to configure cross-building for android -> correctly uses windows ";" path separator
- MacOS zsh terminal configuring ios build -> correctly uses the standard ":" path separator