### PR TITLE
Add macOS universal binary support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ CMake dependency provider for the Conan C and C++ package manager.
 
 Prerequisites:
 * CMake 3.24
-* Conan 2.0.5
+* Conan 2.0.5 (2.1.0 or later for macOS universal binary builds)
 * A CMake-based project that contains a `conanfile.txt` or `conanfile.py` to list the required dependencies.
 
 First, clone this repository in the `develop2` branch.
@@ -90,6 +90,19 @@ The CMake-Conan dependency provider will autodetect and pass the profile informa
   * The output format (`--format`).
   * The build type setting (`-s build_type=...`).
 * Values are semi-colon separated, e.g. `--build=never;--update;--lockfile-out=''`
+
+### macOS universal binaries
+
+For a macOS build that targets two architectures, enable `CONAN_OSX_UNIVERSAL_BINARIES` to have the dependency provider build the Conan dependencies for both and merge them into universal binaries:
+
+```bash
+cmake -B build -S . -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=[path-to-cmake-conan]/conan_provider.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCONAN_OSX_UNIVERSAL_BINARIES=ON
+```
+
+* The option is off by default. Without it, multiple architectures only work if the recipes produce universal binaries themselves.
+* Requires Conan 2.1.0 or later. Only the `arm64` plus `x86_64` pair is supported, and only for macOS targets (iOS, tvOS and watchOS are unaffected).
+* The dependencies are copied into the build tree, once per architecture, so expect a bigger build directory.
+* Reinstalls are skipped while the conanfile, the profiles, the install arguments and the resolved dependency versions are unchanged. A version range that picks up a new package in the local cache reinstalls automatically. Delete `<build>/conan-universal-stamp.txt` to force a reinstall.
 
 
 ## Development, contributors

--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -97,6 +97,25 @@ function(detect_os os os_api_level os_sdk os_subsystem os_version)
 endfunction()
 
 
+function(convert_to_conan_arch host_arch arch)
+    # Converts a host architecture name to the Conan arch setting value, empty for
+    # unknown names
+    set(_arch "")
+    if(host_arch MATCHES "aarch64|arm64|ARM64")
+        set(_arch armv8)
+    elseif(host_arch MATCHES "armv7|armv7-a|armv7l|ARMV7")
+        set(_arch armv7)
+    elseif(host_arch MATCHES armv7s)
+        set(_arch armv7s)
+    elseif(host_arch MATCHES "i686|i386|X86")
+        set(_arch x86)
+    elseif(host_arch MATCHES "AMD64|amd64|x86_64|x64")
+        set(_arch x86_64)
+    endif()
+    set(${arch} "${_arch}" PARENT_SCOPE)
+endfunction()
+
+
 function(detect_arch arch)
     # CMAKE_OSX_ARCHITECTURES can contain multiple architectures, but Conan only supports one.
     # Therefore this code only finds one. If the recipes support multiple architectures, the
@@ -115,23 +134,66 @@ function(detect_arch arch)
     else()
         set(host_arch ${CMAKE_SYSTEM_PROCESSOR})
     endif()
-    if(host_arch MATCHES "aarch64|arm64|ARM64")
-        set(_arch armv8)
-    elseif(host_arch MATCHES "armv7|armv7-a|armv7l|ARMV7")
-        set(_arch armv7)
-    elseif(host_arch MATCHES armv7s)
-        set(_arch armv7s)
-    elseif(host_arch MATCHES "i686|i386|X86")
-        set(_arch x86)
-    elseif(host_arch MATCHES "AMD64|amd64|x86_64|x64")
-        set(_arch x86_64)
-    endif()
+    convert_to_conan_arch("${host_arch}" _arch)
     if(EMSCRIPTEN)
         # https://github.com/emscripten-core/emscripten/blob/4.0.6/cmake/Modules/Platform/Emscripten.cmake#L294C1-L294C80
         set(_arch wasm)
     endif()
     message(STATUS "CMake-Conan: cmake_system_processor=${_arch}")
     set(${arch} ${_arch} PARENT_SCOPE)
+endfunction()
+
+
+function(detect_osx_universal_archs archs)
+    # Two distinct supported architectures in CMAKE_OSX_ARCHITECTURES on macOS mean a
+    # universal binary build: one "conan install" per architecture plus a lipo merge,
+    # since Conan resolves a single architecture per install. The first architecture
+    # is the primary one, it provides the profile arch and the generators. Returns an
+    # empty list for anything else, which falls through to the detect_arch flow.
+    set(${archs} "" PARENT_SCOPE)
+    if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR NOT CMAKE_OSX_ARCHITECTURES)
+        return()
+    endif()
+    # Documented as a ;-list, but also accept the space-separated form
+    string(REPLACE " " ";" _host_archs "${CMAKE_OSX_ARCHITECTURES}")
+    list(REMOVE_ITEM _host_archs "")
+    list(LENGTH _host_archs _host_count)
+    if(_host_count LESS 2)
+        return()
+    endif()
+    if(_host_count GREATER 2)
+        message(FATAL_ERROR "CMake-Conan: at most two architectures are supported for a "
+                "universal binary build, got '${CMAKE_OSX_ARCHITECTURES}'. Set "
+                "CONAN_OSX_UNIVERSAL_BINARIES=OFF to restore the previous single-install behavior.")
+    endif()
+
+    set(_archs "")
+    set(_unsupported "")
+    foreach(_host_arch IN LISTS _host_archs)
+        convert_to_conan_arch("${_host_arch}" _arch)
+        if(_arch MATCHES "^(armv8|x86_64)$")
+            list(APPEND _archs ${_arch})
+        else()
+            list(APPEND _unsupported ${_host_arch})
+        endif()
+    endforeach()
+    if(_unsupported)
+        message(FATAL_ERROR "CMake-Conan: cannot map '${_unsupported}' from "
+                "CMAKE_OSX_ARCHITECTURES='${CMAKE_OSX_ARCHITECTURES}' to a Conan architecture "
+                "for a universal binary build. Supported: arm64 and x86_64. Set "
+                "CONAN_OSX_UNIVERSAL_BINARIES=OFF to restore the previous single-install behavior.")
+    endif()
+    list(REMOVE_DUPLICATES _archs)
+    list(LENGTH _archs _unique_count)
+    if(_unique_count LESS 2)
+        message(FATAL_ERROR "CMake-Conan: CMAKE_OSX_ARCHITECTURES='${CMAKE_OSX_ARCHITECTURES}' "
+                "maps to Conan architecture '${_archs}' more than once; a universal binary "
+                "build needs two distinct architectures. Set CONAN_OSX_UNIVERSAL_BINARIES=OFF "
+                "to restore the previous single-install behavior.")
+    endif()
+
+    message(STATUS "CMake-Conan: cmake_system_processor=${_archs}")
+    set(${archs} ${_archs} PARENT_SCOPE)
 endfunction()
 
 
@@ -372,9 +434,15 @@ macro(append_compiler_executables_configuration)
 endmacro()
 
 
-function(detect_host_profile output_file)
+function(detect_host_profile output_file archs)
     detect_os(os os_api_level os_sdk os_subsystem os_version)
-    detect_arch(arch)
+    if(archs)
+        # Universal binary build: the profile holds the primary arch only, the
+        # installs override it per architecture on the command line
+        list(GET archs 0 arch)
+    else()
+        detect_arch(arch)
+    endif()
     detect_compiler(compiler compiler_version compiler_runtime compiler_runtime_type)
     detect_cxx_standard(${compiler} compiler_cppstd)
     detect_lib_cxx(compiler_libcxx)
@@ -467,10 +535,17 @@ endfunction()
 
 
 function(conan_install)
-    set(conan_output_folder ${CMAKE_BINARY_DIR}/conan)
+    # OUTPUT_FOLDER redirects the output folder (used by per-architecture universal
+    # installs), everything else is passed to "conan install" as-is
+    cmake_parse_arguments(_conan_install "" "OUTPUT_FOLDER" "" ${ARGN})
+    if(_conan_install_OUTPUT_FOLDER)
+        set(conan_output_folder ${_conan_install_OUTPUT_FOLDER})
+    else()
+        set(conan_output_folder ${CMAKE_BINARY_DIR}/conan)
+    endif()
     # Invoke "conan install" with the provided arguments
     set(conan_args -of=${conan_output_folder})
-    list(JOIN ARGN " " argn_str)
+    list(JOIN _conan_install_UNPARSED_ARGUMENTS " " argn_str)
     message(STATUS "CMake-Conan: conan install ${CMAKE_SOURCE_DIR} ${conan_args} ${argn_str}")
 
 
@@ -485,7 +560,7 @@ function(conan_install)
         endif()
     endif()
 
-    execute_process(COMMAND ${CONAN_COMMAND} install ${CMAKE_SOURCE_DIR} ${conan_args} ${ARGN} --format=json
+    execute_process(COMMAND ${CONAN_COMMAND} install ${CMAKE_SOURCE_DIR} ${conan_args} ${_conan_install_UNPARSED_ARGUMENTS} --format=json
                     RESULT_VARIABLE return_code
                     OUTPUT_VARIABLE conan_stdout
                     ERROR_VARIABLE conan_stderr
@@ -572,6 +647,429 @@ macro(construct_profile_argument argument_variable profile_list)
 endmacro()
 
 
+macro(conan_install_osx_universal)
+    # One "conan install" per architecture, and each install deploys its packages into
+    # the build tree for the lipo merge. The secondary architecture installs into a side
+    # output folder first. The primary architecture installs into the default folder last
+    # so CONAN_GENERATORS_FOLDER ends up pointing at its generators. Both installs
+    # consume the probed lockfile, so they install one identical dependency snapshot.
+    set(_conan_universal_lockfile_args "")
+    if(EXISTS "${_conan_universal_lockfile}")
+        set(_conan_universal_lockfile_args --lockfile=${_conan_universal_lockfile} --lockfile-partial)
+    endif()
+    conan_install(OUTPUT_FOLDER ${CMAKE_BINARY_DIR}/conan-${_conan_secondary_arch} ${ARGN} ${_conan_universal_lockfile_args} -s:h arch=${_conan_secondary_arch} --deployer=full_deploy --deployer-folder=${CMAKE_BINARY_DIR}/conan-deploy-${_conan_secondary_arch})
+    conan_install(${ARGN} ${_conan_universal_lockfile_args} -s:h arch=${_conan_primary_arch} --deployer=full_deploy --deployer-folder=${CMAKE_BINARY_DIR}/conan-deploy-${_conan_primary_arch})
+    unset(_conan_universal_lockfile_args)
+endmacro()
+
+
+function(conan_universal_lipo_arch conan_arch lipo_arch)
+    # Converts a Conan arch setting value to the lipo architecture name
+    if(conan_arch STREQUAL "armv8")
+        set(${lipo_arch} arm64 PARENT_SCOPE)
+    elseif(conan_arch STREQUAL "x86_64")
+        set(${lipo_arch} x86_64 PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "CMake-Conan: no lipo architecture name for '${conan_arch}'")
+    endif()
+endfunction()
+
+
+function(conan_universal_arch_macro conan_arch arch_macro)
+    # Converts a Conan arch setting value to the compiler-defined architecture macro
+    if(conan_arch STREQUAL "armv8")
+        set(${arch_macro} __aarch64__ PARENT_SCOPE)
+    elseif(conan_arch STREQUAL "x86_64")
+        set(${arch_macro} __x86_64__ PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "CMake-Conan: no architecture macro for '${conan_arch}'")
+    endif()
+endfunction()
+
+
+function(conan_universal_count counter)
+    get_property(_count GLOBAL PROPERTY ${counter})
+    math(EXPR _count "${_count} + 1")
+    set_property(GLOBAL PROPERTY ${counter} ${_count})
+endfunction()
+
+
+function(conan_universal_error error_message)
+    conan_universal_count(_CONAN_UNIVERSAL_ERRORS)
+    message(SEND_ERROR "CMake-Conan: ${error_message}")
+endfunction()
+
+
+function(conan_universal_lipo_archs path archs)
+    # Architectures in a Mach-O file or static archive, empty for anything else
+    execute_process(COMMAND ${CONAN_LIPO_PROGRAM} -archs "${path}"
+                    RESULT_VARIABLE _result OUTPUT_VARIABLE _output
+                    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(_result EQUAL 0)
+        string(REPLACE " " ";" _output "${_output}")
+        set(${archs} "${_output}" PARENT_SCOPE)
+    else()
+        set(${archs} "" PARENT_SCOPE)
+    endif()
+endfunction()
+
+
+function(conan_universal_lipo_merge primary secondary)
+    # lipo-merges secondary into primary in place, verifying architectures
+    conan_universal_lipo_archs("${primary}" _primary_archs)
+    if(NOT _primary_archs STREQUAL _conan_primary_lipo_arch)
+        message(FATAL_ERROR "CMake-Conan: unexpected architectures [${_primary_archs}] in ${primary}, "
+                            "expected [${_conan_primary_lipo_arch}] (trees already merged, or architectures "
+                            "swapped?); if your recipes intentionally produce universal (fat) binaries, "
+                            "set CONAN_OSX_UNIVERSAL_BINARIES=OFF")
+    endif()
+    conan_universal_lipo_archs("${secondary}" _secondary_archs)
+    if(NOT _secondary_archs STREQUAL _conan_secondary_lipo_arch)
+        message(FATAL_ERROR "CMake-Conan: unexpected architectures [${_secondary_archs}] in ${secondary}, "
+                            "expected [${_conan_secondary_lipo_arch}] (trees already merged, or architectures "
+                            "swapped?); if your recipes intentionally produce universal (fat) binaries, "
+                            "set CONAN_OSX_UNIVERSAL_BINARIES=OFF")
+    endif()
+
+    # CMake cannot query the executable bit, and test(1) is always available on macOS
+    execute_process(COMMAND test -x "${primary}" RESULT_VARIABLE _not_executable)
+    set(_tmp "${primary}.lipo-tmp")
+    execute_process(COMMAND ${CONAN_LIPO_PROGRAM} -create "${primary}" "${secondary}" -output "${_tmp}"
+                    RESULT_VARIABLE _result ERROR_VARIABLE _error)
+    if(NOT _result EQUAL 0)
+        file(REMOVE "${_tmp}")
+        conan_universal_error("lipo -create failed for ${primary}: ${_error}")
+        return()
+    endif()
+    if(_not_executable EQUAL 0)
+        file(CHMOD "${_tmp}" PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                                         GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+    else()
+        file(CHMOD "${_tmp}" PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+    endif()
+    file(RENAME "${_tmp}" "${primary}")
+
+    conan_universal_lipo_archs("${primary}" _merged_archs)
+    set(_expected_archs ${_conan_primary_lipo_arch} ${_conan_secondary_lipo_arch})
+    list(SORT _expected_archs)
+    list(SORT _merged_archs)
+    if(NOT _merged_archs STREQUAL _expected_archs)
+        message(FATAL_ERROR "CMake-Conan: merge produced unexpected architectures [${_merged_archs}] in ${primary}")
+    endif()
+    conan_universal_count(_CONAN_UNIVERSAL_MERGED)
+endfunction()
+
+
+function(conan_universal_package_set deploy_root packages)
+    # The sorted list of <name>/<version> under <deploy_root>/full_deploy/host
+    set(_host "${deploy_root}/full_deploy/host")
+    if(NOT IS_DIRECTORY "${_host}")
+        message(FATAL_ERROR "CMake-Conan: missing deploy tree ${_host}")
+    endif()
+    file(GLOB _packages RELATIVE "${_host}" "${_host}/*/*")
+    list(SORT _packages)
+    set(${packages} "${_packages}" PARENT_SCOPE)
+endfunction()
+
+
+function(conan_universal_map_arch_path rel from_arch to_arch mapped count)
+    # Swaps the <from_arch> path component for <to_arch> and reports how many such
+    # components the path has, the swap is only unambiguous for at most one
+    string(REPLACE "/" ";" _components "${rel}")
+    set(_count 0)
+    foreach(_component IN LISTS _components)
+        if(_component STREQUAL from_arch)
+            math(EXPR _count "${_count} + 1")
+        endif()
+    endforeach()
+    string(REPLACE "/${from_arch}/" "/${to_arch}/" _mapped "/${rel}/")
+    string(LENGTH "${_mapped}" _mapped_length)
+    math(EXPR _mapped_length "${_mapped_length} - 2")
+    string(SUBSTRING "${_mapped}" 1 ${_mapped_length} _mapped)
+    set(${mapped} "${_mapped}" PARENT_SCOPE)
+    set(${count} ${_count} PARENT_SCOPE)
+endfunction()
+
+
+function(conan_universal_dispatch_header primary secondary)
+    # Replaces a per-architecture header with an architecture-dispatching wrapper. The
+    # primary and secondary contents are kept next to the original as
+    # <stem>.<lipo arch>.<ext> and the original becomes an #if/#include dispatcher.
+    cmake_path(GET primary STEM LAST_ONLY _stem)
+    cmake_path(GET primary EXTENSION LAST_ONLY _ext)
+    cmake_path(GET primary PARENT_PATH _dir)
+    set(_primary_variant "${_stem}.${_conan_primary_lipo_arch}${_ext}")
+    set(_secondary_variant "${_stem}.${_conan_secondary_lipo_arch}${_ext}")
+    file(RENAME "${primary}" "${_dir}/${_primary_variant}")
+    file(COPY_FILE "${secondary}" "${_dir}/${_secondary_variant}")
+    file(WRITE "${primary}"
+"/* Generated by conan_provider.cmake: this header differs between the
+ * merged architectures, so it includes the variant for the target arch. */
+#if defined(${_conan_primary_arch_macro})
+#include \"${_primary_variant}\"
+#elif defined(${_conan_secondary_arch_macro})
+#include \"${_secondary_variant}\"
+#else
+#error \"conan_provider.cmake: no header variant for this architecture\"
+#endif
+")
+    conan_universal_count(_CONAN_UNIVERSAL_DISPATCHED)
+    message(STATUS "CMake-Conan: dispatching per-architecture header ${primary}")
+endfunction()
+
+
+function(conan_universal_merge_deploy_trees)
+    # Walks the secondary deploy tree and merges each file into the primary one. Files
+    # identical between the architectures are shared from the primary tree. Headers
+    # that differ get an architecture-dispatching wrapper. Mach-O files are lipo-merged
+    # into their primary counterparts.
+    file(GLOB_RECURSE _files LIST_DIRECTORIES false RELATIVE "${_conan_secondary_deploy}"
+         "${_conan_secondary_deploy}/*")
+    foreach(_rel IN LISTS _files)
+        set(_secondary_file "${_conan_secondary_deploy}/${_rel}")
+        if(IS_SYMLINK "${_secondary_file}")
+            continue()
+        endif()
+
+        conan_universal_map_arch_path("${_rel}" "${_conan_secondary_arch}" "${_conan_primary_arch}"
+                                      _mapped _arch_components)
+        if(_arch_components GREATER 1)
+            conan_universal_error("multiple '${_conan_secondary_arch}' path components in ${_rel}")
+            continue()
+        endif()
+        set(_primary_file "${_conan_primary_deploy}/${_mapped}")
+
+        # Identical files are shared from the primary tree as-is
+        if(EXISTS "${_primary_file}")
+            file(SHA256 "${_primary_file}" _primary_hash)
+            file(SHA256 "${_secondary_file}" _secondary_hash)
+            if(_primary_hash STREQUAL _secondary_hash)
+                conan_universal_count(_CONAN_UNIVERSAL_COMPARED)
+                continue()
+            endif()
+        endif()
+
+        cmake_path(GET _mapped PARENT_PATH _mapped_dir)
+        if("/${_mapped_dir}/" MATCHES "/include/")
+            # Checked before any lipo probing, no binaries live under include/
+            if(NOT EXISTS "${_primary_file}")
+                conan_universal_error("no primary counterpart for header ${_rel}")
+                continue()
+            endif()
+            cmake_path(GET _mapped EXTENSION LAST_ONLY _ext)
+            if(_ext MATCHES "^\\.(h|hpp|hxx|hh|inc|ipp|tcc)$")
+                conan_universal_dispatch_header("${_primary_file}" "${_secondary_file}")
+            else()
+                conan_universal_error("non-header include file differs between architectures: ${_mapped}")
+            endif()
+        else()
+            conan_universal_lipo_archs("${_secondary_file}" _file_archs)
+            if(_file_archs)
+                if(_mapped STREQUAL _rel)
+                    conan_universal_error("binary outside an architecture-specific directory: ${_rel}")
+                elseif(NOT EXISTS "${_primary_file}")
+                    conan_universal_error("no primary counterpart for ${_rel}")
+                else()
+                    conan_universal_lipo_merge("${_primary_file}" "${_secondary_file}")
+                endif()
+            endif()
+            # Everything else (licenses, conaninfo.txt, pkg-config and cmake files with
+            # embedded per-package paths) legitimately differs per architecture and is
+            # not consumed by the CMakeDeps flow
+        endif()
+    endforeach()
+endfunction()
+
+
+function(conan_universal_verify_primary_only)
+    # Walks the primary deploy tree and reports headers and binaries with no secondary
+    # counterpart, they would silently stay single-architecture in the merged tree.
+    # Must run before the merge, which creates primary-only dispatch variant files.
+    file(GLOB_RECURSE _files LIST_DIRECTORIES false RELATIVE "${_conan_primary_deploy}"
+         "${_conan_primary_deploy}/*")
+    foreach(_rel IN LISTS _files)
+        set(_primary_file "${_conan_primary_deploy}/${_rel}")
+        if(IS_SYMLINK "${_primary_file}")
+            continue()
+        endif()
+        conan_universal_map_arch_path("${_rel}" "${_conan_primary_arch}" "${_conan_secondary_arch}"
+                                      _mapped _arch_components)
+        if(_arch_components GREATER 1)
+            conan_universal_error("multiple '${_conan_primary_arch}' path components in ${_rel}")
+            continue()
+        endif()
+        if(EXISTS "${_conan_secondary_deploy}/${_mapped}")
+            continue()
+        endif()
+        cmake_path(GET _mapped PARENT_PATH _mapped_dir)
+        if("/${_mapped_dir}/" MATCHES "/include/")
+            conan_universal_error("include file missing for architecture ${_conan_secondary_arch}: ${_rel}")
+        else()
+            conan_universal_lipo_archs("${_primary_file}" _file_archs)
+            if(_file_archs)
+                conan_universal_error("binary missing for architecture ${_conan_secondary_arch}: ${_rel}")
+            endif()
+        endif()
+    endforeach()
+endfunction()
+
+
+function(conan_universal_merge)
+    # Merges the secondary architecture's binaries into the primary deploy tree with
+    # lipo, so the dependencies become universal in place. Raises errors as described
+    # in the comment block above.
+    foreach(_counter _CONAN_UNIVERSAL_MERGED _CONAN_UNIVERSAL_COMPARED
+                     _CONAN_UNIVERSAL_DISPATCHED _CONAN_UNIVERSAL_ERRORS)
+        set_property(GLOBAL PROPERTY ${_counter} 0)
+    endforeach()
+
+    conan_universal_lipo_arch(${_conan_primary_arch} _conan_primary_lipo_arch)
+    conan_universal_lipo_arch(${_conan_secondary_arch} _conan_secondary_lipo_arch)
+    conan_universal_arch_macro(${_conan_primary_arch} _conan_primary_arch_macro)
+    conan_universal_arch_macro(${_conan_secondary_arch} _conan_secondary_arch_macro)
+    set(_conan_primary_deploy "${CMAKE_BINARY_DIR}/conan-deploy-${_conan_primary_arch}")
+    set(_conan_secondary_deploy "${CMAKE_BINARY_DIR}/conan-deploy-${_conan_secondary_arch}")
+
+    conan_universal_package_set("${_conan_primary_deploy}" _primary_packages)
+    conan_universal_package_set("${_conan_secondary_deploy}" _secondary_packages)
+    if(NOT _primary_packages STREQUAL _secondary_packages)
+        set(_only_primary "${_primary_packages}")
+        if(_secondary_packages)
+            list(REMOVE_ITEM _only_primary ${_secondary_packages})
+        endif()
+        set(_only_secondary "${_secondary_packages}")
+        if(_primary_packages)
+            list(REMOVE_ITEM _only_secondary ${_primary_packages})
+        endif()
+        message(FATAL_ERROR "CMake-Conan: package sets differ between architectures: "
+                            "only ${_conan_primary_arch}: [${_only_primary}], "
+                            "only ${_conan_secondary_arch}: [${_only_secondary}]")
+    endif()
+
+    conan_universal_verify_primary_only()
+    conan_universal_merge_deploy_trees()
+
+    list(LENGTH _primary_packages _package_count)
+    get_property(_merged GLOBAL PROPERTY _CONAN_UNIVERSAL_MERGED)
+    get_property(_compared GLOBAL PROPERTY _CONAN_UNIVERSAL_COMPARED)
+    get_property(_dispatched GLOBAL PROPERTY _CONAN_UNIVERSAL_DISPATCHED)
+    get_property(_errors GLOBAL PROPERTY _CONAN_UNIVERSAL_ERRORS)
+    message(STATUS "CMake-Conan: ${_package_count} packages, ${_merged} binaries merged, "
+                   "${_compared} files identical, "
+                   "${_dispatched} headers dispatched per architecture, ${_errors} errors")
+    if(_errors GREATER 0)
+        message(FATAL_ERROR "CMake-Conan: ${_errors} error(s) reported above")
+    endif()
+endfunction()
+
+
+function(conan_universal_probe_lockfile lockfile)
+    # Resolves the dependency graph, without installing or deploying, and captures it
+    # as a lockfile. The lockfile joins the stamp inputs, so a version range that
+    # resolves to a new package triggers a reinstall. The installs then consume the
+    # lockfile and both architectures install one identical snapshot. No lockfile on
+    # failure, which forces a reinstall.
+    file(REMOVE "${lockfile}")
+    list(GET _build_configs 0 _probe_build_type)
+    set(_probe_update "")
+    if("--update" IN_LIST CONAN_INSTALL_ARGS)
+        set(_probe_update --update)
+    endif()
+    execute_process(COMMAND ${CONAN_COMMAND} lock create ${CMAKE_SOURCE_DIR}
+                            ${_host_profile_flags} ${_build_profile_flags}
+                            -s:h arch=${_conan_primary_arch} -s build_type=${_probe_build_type}
+                            ${_probe_update} --lockfile-out=${lockfile}
+                    RESULT_VARIABLE _result OUTPUT_QUIET ERROR_QUIET)
+    if(NOT _result EQUAL 0)
+        file(REMOVE "${lockfile}")
+    endif()
+endfunction()
+
+
+function(conan_universal_stamp_inputs_hash hash)
+    # Hash of everything that feeds the installs: conanfile, resolved profiles,
+    # global.conf (not covered by "conan profile show"), the probed lockfile, install
+    # arguments and the Conan version. Empty on failure, which forces a reinstall.
+    set(${hash} "" PARENT_SCOPE)
+
+    if(NOT EXISTS "${_conan_universal_lockfile}")
+        return()
+    endif()
+    file(READ "${_conan_universal_lockfile}" _lockfile_content)
+
+    if(EXISTS "${CMAKE_SOURCE_DIR}/conanfile.py")
+        set(_conanfile "${CMAKE_SOURCE_DIR}/conanfile.py")
+    elseif(EXISTS "${CMAKE_SOURCE_DIR}/conanfile.txt")
+        set(_conanfile "${CMAKE_SOURCE_DIR}/conanfile.txt")
+    else()
+        return()
+    endif()
+    file(SHA256 "${_conanfile}" _conanfile_hash)
+
+    execute_process(COMMAND ${CONAN_COMMAND} profile show ${_host_profile_flags} ${_build_profile_flags}
+                    RESULT_VARIABLE _result OUTPUT_VARIABLE _profiles ERROR_QUIET)
+    if(NOT _result EQUAL 0)
+        return()
+    endif()
+
+    execute_process(COMMAND ${CONAN_COMMAND} config home
+                    RESULT_VARIABLE _result OUTPUT_VARIABLE _conan_home
+                    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT _result EQUAL 0)
+        return()
+    endif()
+    set(_global_conf "")
+    if(EXISTS "${_conan_home}/global.conf")
+        file(READ "${_conan_home}/global.conf" _global_conf)
+    endif()
+
+    string(SHA256 _hash "${CONAN_CURRENT_VERSION}\n${_conan_universal_archs}\n${_build_configs}\n\
+${CMAKE_BUILD_TYPE}\n${CONAN_INSTALL_ARGS}\n${_host_profile_flags}\n${_build_profile_flags}\n\
+${_conanfile}\n${_conanfile_hash}\n${_profiles}\n${_global_conf}\n${_lockfile_content}")
+    set(${hash} "${_hash}" PARENT_SCOPE)
+endfunction()
+
+
+function(conan_universal_stamp_check stamp_file inputs_hash valid generators_folder)
+    # Valid when the stamp matches the inputs hash and its outputs are still in place
+    set(${valid} FALSE PARENT_SCOPE)
+    set(${generators_folder} "" PARENT_SCOPE)
+    if(NOT inputs_hash OR NOT EXISTS "${stamp_file}")
+        return()
+    endif()
+    file(STRINGS "${stamp_file}" _lines)
+    list(LENGTH _lines _line_count)
+    if(_line_count LESS 5)
+        return()
+    endif()
+    list(GET _lines 0 _format)
+    list(GET _lines 1 _hash)
+    list(GET _lines 2 _generators)
+    list(GET _lines 3 _primary)
+    list(GET _lines 4 _secondary)
+    if(NOT _format STREQUAL "1" OR NOT _hash STREQUAL inputs_hash)
+        return()
+    endif()
+    if(NOT IS_DIRECTORY "${_generators}"
+       OR NOT IS_DIRECTORY "${CMAKE_BINARY_DIR}/conan-deploy-${_primary}/full_deploy/host"
+       OR NOT IS_DIRECTORY "${CMAKE_BINARY_DIR}/conan-deploy-${_secondary}/full_deploy/host")
+        return()
+    endif()
+    set(${valid} TRUE PARENT_SCOPE)
+    set(${generators_folder} "${_generators}" PARENT_SCOPE)
+endfunction()
+
+
+function(conan_universal_stamp_write stamp_file inputs_hash)
+    if(NOT inputs_hash)
+        return()
+    endif()
+    get_property(_generators GLOBAL PROPERTY CONAN_GENERATORS_FOLDER)
+    file(WRITE "${stamp_file}"
+         "1\n${inputs_hash}\n${_generators}\n${_conan_primary_arch}\n${_conan_secondary_arch}\n")
+endfunction()
+
+
 macro(conan_provide_dependency method package_name)
     set_property(GLOBAL PROPERTY CONAN_PROVIDE_DEPENDENCY_INVOKED TRUE)
     get_property(_conan_install_success GLOBAL PROPERTY CONAN_INSTALL_SUCCESS)
@@ -583,8 +1081,22 @@ macro(conan_provide_dependency method package_name)
         if("default" IN_LIST CONAN_HOST_PROFILE OR "default" IN_LIST CONAN_BUILD_PROFILE)
             conan_profile_detect_default()
         endif()
+        set(_conan_universal_archs "")
+        if(CONAN_OSX_UNIVERSAL_BINARIES)
+            detect_osx_universal_archs(_conan_universal_archs)
+        endif()
+        if(_conan_universal_archs)
+            # Universal binary build: fail fast on its requirements before any install
+            if(CONAN_CURRENT_VERSION VERSION_LESS 2.1.0)
+                message(FATAL_ERROR "CMake-Conan: Universal binary builds require Conan 2.1.0 or later "
+                        "for 'conan install --deployer-folder', found ${CONAN_CURRENT_VERSION}")
+            endif()
+            # The lipo found on the PATH is an xcode-select shim, and the cache
+            # variable doubles as a user override
+            find_program(CONAN_LIPO_PROGRAM lipo REQUIRED)
+        endif()
         if("auto-cmake" IN_LIST CONAN_HOST_PROFILE)
-            detect_host_profile(${CMAKE_BINARY_DIR}/conan_host_profile)
+            detect_host_profile(${CMAKE_BINARY_DIR}/conan_host_profile "${_conan_universal_archs}")
         endif()
         construct_profile_argument(_host_profile_flags CONAN_HOST_PROFILE)
         construct_profile_argument(_build_profile_flags CONAN_BUILD_PROFILE)
@@ -601,7 +1113,7 @@ macro(conan_provide_dependency method package_name)
         endif()
 
         get_property(_multiconfig_generator GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-        
+
         if(DEFINED CONAN_INSTALL_BUILD_CONFIGURATIONS)
             # Configurations are specified by the project or user
             set(_build_configs "${CONAN_INSTALL_BUILD_CONFIGURATIONS}")
@@ -621,15 +1133,84 @@ macro(conan_provide_dependency method package_name)
             
         endif()
 
-        list(JOIN _build_configs ", " _build_configs_msg)
-        message(STATUS "CMake-Conan: Installing configuration(s): ${_build_configs_msg}")
-        foreach(_build_config IN LISTS _build_configs)
-            set(_self_build_config "")
-            if(NOT _multiconfig_generator AND NOT _build_config STREQUAL "${CMAKE_BUILD_TYPE}")
-                set(_self_build_config -s &:build_type=${CMAKE_BUILD_TYPE})
+        set(_conan_universal_uptodate FALSE)
+        if(_conan_universal_archs)
+            if(NOT _build_configs)
+                message(FATAL_ERROR "CMake-Conan: a universal binary build needs at least one build "
+                        "type, set CMAKE_BUILD_TYPE or CONAN_INSTALL_BUILD_CONFIGURATIONS")
             endif()
-            conan_install(${_host_profile_flags} ${_build_profile_flags} -s build_type=${_build_config} ${_self_build_config} ${CONAN_INSTALL_ARGS})
-        endforeach()
+            list(GET _conan_universal_archs 0 _conan_primary_arch)
+            list(GET _conan_universal_archs 1 _conan_secondary_arch)
+            set(_conan_universal_stamp ${CMAKE_BINARY_DIR}/conan-universal-stamp.txt)
+            set(_conan_universal_lockfile ${CMAKE_BINARY_DIR}/conan-universal.lock)
+            conan_universal_probe_lockfile("${_conan_universal_lockfile}")
+            conan_universal_stamp_inputs_hash(_conan_universal_hash)
+            conan_universal_stamp_check("${_conan_universal_stamp}" "${_conan_universal_hash}"
+                                        _conan_universal_uptodate _conan_universal_generators)
+        elseif(EXISTS "${CMAKE_BINARY_DIR}/conan-universal-stamp.txt")
+            # The previous configure was a universal binary build and this one is not:
+            # drop its outputs, since the generators in the output folder point into
+            # the deploy trees removed here
+            message(STATUS "CMake-Conan: removing outputs of previous universal binary build")
+            file(STRINGS "${CMAKE_BINARY_DIR}/conan-universal-stamp.txt" _conan_universal_stale)
+            file(REMOVE "${CMAKE_BINARY_DIR}/conan-universal-stamp.txt"
+                        "${CMAKE_BINARY_DIR}/conan-universal.lock")
+            file(REMOVE_RECURSE "${CMAKE_BINARY_DIR}/conan")
+            list(LENGTH _conan_universal_stale _conan_universal_stale_count)
+            if(_conan_universal_stale_count GREATER_EQUAL 5)
+                list(GET _conan_universal_stale 3 _conan_universal_stale_primary)
+                list(GET _conan_universal_stale 4 _conan_universal_stale_secondary)
+                file(REMOVE_RECURSE "${CMAKE_BINARY_DIR}/conan-${_conan_universal_stale_secondary}"
+                                    "${CMAKE_BINARY_DIR}/conan-deploy-${_conan_universal_stale_primary}"
+                                    "${CMAKE_BINARY_DIR}/conan-deploy-${_conan_universal_stale_secondary}")
+                unset(_conan_universal_stale_primary)
+                unset(_conan_universal_stale_secondary)
+            endif()
+            unset(_conan_universal_stale)
+            unset(_conan_universal_stale_count)
+        endif()
+
+        if(_conan_universal_uptodate)
+            message(STATUS "CMake-Conan: Universal binary build up to date, skipping conan install "
+                           "(delete ${_conan_universal_stamp} to force)")
+            set_property(GLOBAL PROPERTY CONAN_GENERATORS_FOLDER "${_conan_universal_generators}")
+            set_property(GLOBAL PROPERTY CONAN_INSTALL_SUCCESS TRUE)
+            # reconfigure on conanfile changes, like conan_install does
+            if(EXISTS "${CMAKE_SOURCE_DIR}/conanfile.py")
+                set_property(DIRECTORY ${CMAKE_SOURCE_DIR} APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/conanfile.py")
+            elseif(EXISTS "${CMAKE_SOURCE_DIR}/conanfile.txt")
+                set_property(DIRECTORY ${CMAKE_SOURCE_DIR} APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/conanfile.txt")
+            endif()
+        else()
+            if(_conan_universal_archs)
+                message(STATUS "CMake-Conan: Universal binary build, installing each architecture separately (${CMAKE_OSX_ARCHITECTURES})")
+                # Remove the stamp first, it is only re-written after a successful
+                # merge. An interrupted run never looks up to date. Start from clean
+                # outputs so the merge only sees freshly deployed files.
+                file(REMOVE "${_conan_universal_stamp}")
+                file(REMOVE_RECURSE "${CMAKE_BINARY_DIR}/conan"
+                                    "${CMAKE_BINARY_DIR}/conan-${_conan_secondary_arch}"
+                                    "${CMAKE_BINARY_DIR}/conan-deploy-${_conan_primary_arch}"
+                                    "${CMAKE_BINARY_DIR}/conan-deploy-${_conan_secondary_arch}")
+            endif()
+            list(JOIN _build_configs ", " _build_configs_msg)
+            message(STATUS "CMake-Conan: Installing configuration(s): ${_build_configs_msg}")
+            foreach(_build_config IN LISTS _build_configs)
+                set(_self_build_config "")
+                if(NOT _multiconfig_generator AND NOT _build_config STREQUAL "${CMAKE_BUILD_TYPE}")
+                    set(_self_build_config -s &:build_type=${CMAKE_BUILD_TYPE})
+                endif()
+                if(_conan_universal_archs)
+                    conan_install_osx_universal(${_host_profile_flags} ${_build_profile_flags} -s build_type=${_build_config} ${_self_build_config} ${CONAN_INSTALL_ARGS})
+                else()
+                    conan_install(${_host_profile_flags} ${_build_profile_flags} -s build_type=${_build_config} ${_self_build_config} ${CONAN_INSTALL_ARGS})
+                endif()
+            endforeach()
+            if(_conan_universal_archs)
+                conan_universal_merge()
+                conan_universal_stamp_write("${_conan_universal_stamp}" "${_conan_universal_hash}")
+            endif()
+        endif()
 
         get_property(_conan_generators_folder GLOBAL PROPERTY CONAN_GENERATORS_FOLDER)
         if(EXISTS "${_conan_generators_folder}/conan_cmakedeps_paths.cmake")
@@ -639,6 +1220,14 @@ macro(conan_provide_dependency method package_name)
 
         unset(_self_build_config)
         unset(_multiconfig_generator)
+        unset(_conan_universal_archs)
+        unset(_conan_primary_arch)
+        unset(_conan_secondary_arch)
+        unset(_conan_universal_uptodate)
+        unset(_conan_universal_stamp)
+        unset(_conan_universal_lockfile)
+        unset(_conan_universal_hash)
+        unset(_conan_universal_generators)
         unset(_build_configs)
         unset(_build_configs_msg)
         unset(_host_profile_flags)
@@ -712,6 +1301,11 @@ cmake_language(DEFER DIRECTORY "${CMAKE_SOURCE_DIR}" CALL conan_provide_dependen
 set(CONAN_HOST_PROFILE "default;auto-cmake" CACHE STRING "Conan host profile")
 set(CONAN_BUILD_PROFILE "default" CACHE STRING "Conan build profile")
 set(CONAN_INSTALL_ARGS "--build=missing" CACHE STRING "Command line arguments for conan install")
+option(CONAN_OSX_UNIVERSAL_BINARIES
+       "On macOS with two architectures in CMAKE_OSX_ARCHITECTURES, build the dependencies \
+for each architecture separately and lipo-merge them into universal binaries. When OFF (the \
+default), a single install for the first architecture is used, which only works if the \
+recipes produce universal binaries themselves." OFF)
 
 find_program(_cmake_program NAMES cmake NO_PACKAGE_ROOT_PATH NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH NO_CMAKE_FIND_ROOT_PATH)
 if(NOT _cmake_program)

--- a/tests/resources/macos_universal/CMakeLists.txt
+++ b/tests/resources/macos_universal/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.24)
+project(MyApp CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+find_package(hello REQUIRED)
+find_package(bye REQUIRED)
+find_package(archconfig REQUIRED)
+add_executable(app main.cpp)
+target_link_libraries(app hello::hello bye::bye archconfig::archconfig)

--- a/tests/resources/macos_universal/conanfile.txt
+++ b/tests/resources/macos_universal/conanfile.txt
@@ -1,0 +1,7 @@
+[requires]
+hello/0.1
+bye/0.1
+archconfig/0.1
+
+[generators]
+CMakeConfigDeps

--- a/tests/resources/macos_universal/main.cpp
+++ b/tests/resources/macos_universal/main.cpp
@@ -1,0 +1,12 @@
+#include <iostream>
+#include "hello.h"
+#include "bye.h"
+#include "archconfig.h"
+#include "archconfig_arch.h"
+
+int main(){
+    hello();
+    bye();
+    archconfig();
+    std::cout << "archconfig: " << ARCHCONFIG_ARCH << std::endl;
+}

--- a/tests/resources/macos_universal_archs/CMakeLists.txt
+++ b/tests/resources/macos_universal_archs/CMakeLists.txt
@@ -1,0 +1,6 @@
+# No enabled languages: exercises the architecture validation in the dependency
+# provider without requiring a working compiler for the requested architectures
+cmake_minimum_required(VERSION 3.24)
+project(ArchsOnly NONE)
+
+find_package(hello REQUIRED)

--- a/tests/resources/macos_universal_archs/conanfile.txt
+++ b/tests/resources/macos_universal_archs/conanfile.txt
@@ -1,0 +1,5 @@
+[requires]
+hello/0.1
+
+[generators]
+CMakeConfigDeps

--- a/tests/resources/recipes/archconfig/CMakeLists.txt
+++ b/tests/resources/recipes/archconfig/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.15)
+project(archconfig CXX)
+
+add_library(archconfig src/archconfig.cpp)
+
+# Generated public header that legitimately differs per architecture: Conan's
+# CMakeToolchain sets CMAKE_OSX_ARCHITECTURES to the single architecture of each
+# per-architecture install
+if(CMAKE_OSX_ARCHITECTURES)
+    set(_arch "${CMAKE_OSX_ARCHITECTURES}")
+else()
+    set(_arch "${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/include/archconfig_arch.h
+     "#define ARCHCONFIG_ARCH \"${_arch}\"\n")
+
+target_include_directories(archconfig PUBLIC include ${CMAKE_CURRENT_BINARY_DIR}/include)
+
+set_target_properties(archconfig PROPERTIES
+                      PUBLIC_HEADER "include/archconfig.h;${CMAKE_CURRENT_BINARY_DIR}/include/archconfig_arch.h")
+install(TARGETS archconfig)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -83,13 +83,13 @@ def setup_conan_home(conan_home_dir, tmp_path_factory):
     run("conan export . -vquiet")
 
     # additional recipes to export from resources, overlay on top of `hello` and export
-    additional_recipes = ['boost', 'bye', 'cmake-module-only', 'cmake-module-with-dependency']
+    additional_recipes = ['boost', 'bye', 'cmake-module-only', 'cmake-module-with-dependency', 'archconfig']
 
     for recipe in additional_recipes:
         recipe_dir = tmp_path_factory.mktemp(f"temp_{recipe}")
         os.chdir(recipe_dir.as_posix())
         run(f"conan new cmake_lib -d name={recipe} -d version=0.1 -f -vquiet")
-        shutil.copy2(src_dir / 'tests' / 'resources' / 'recipes' / recipe / 'conanfile.py', ".")
+        shutil.copytree(src_dir / 'tests' / 'resources' / 'recipes' / recipe, ".", dirs_exist_ok=True)
         run("conan export . -vquiet")
 
     # Additional profiles for testing
@@ -686,6 +686,195 @@ class TestAppleOS:
         assert "os.sdk=watchsimulator" in out
         assert "os.version=7.0" in out
         assert "compiler.libcxx=libc++" in out
+
+
+@darwin
+class TestMacosUniversal:
+    # Class-scoped workdir: the tests build on each other in declaration order
+    # (test_universal_build creates the stamp that test_universal_reconfigure_uses_stamp checks)
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_universal_workdir(self, tmp_path_factory):
+        workdir = tmp_path_factory.mktemp("test_macos_universal")
+        source_dir, binary_dir = setup_cmake_workdir(workdir, resource_dirs=['macos_universal'])
+        TestMacosUniversal.source_dir = source_dir
+        TestMacosUniversal.binary_dir = binary_dir
+        cwd = os.getcwd()
+        os.chdir(binary_dir.as_posix())
+        yield
+        os.chdir(cwd)
+
+    def test_universal_build(self, capfd):
+        "Both architectures are installed, merged with lipo, and the app is universal"
+        run(f"cmake -S {self.source_dir} -B {self.binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider} "
+            "-DCMAKE_BUILD_TYPE=Release -DCONAN_OSX_UNIVERSAL_BINARIES=ON '-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64'")
+        out, _ = capfd.readouterr()
+        assert "CMake-Conan: Universal binary build, installing each architecture separately" in out
+        assert "cmake_system_processor=armv8;x86_64" in out
+        assert "--deployer=full_deploy" in out
+        assert "dispatching per-architecture header" in out
+        assert "archconfig_arch.h" in out
+        assert re.search(r"CMake-Conan: 3 packages, \d+ binaries merged, \d+ files identical, "
+                         r"\d+ headers dispatched per architecture, 0 errors", out)
+        run("cmake --build .")
+        archs = subprocess.check_output("lipo -archs ./app", shell=True, text=True)
+        assert set(archs.split()) == {"arm64", "x86_64"}
+        run("./app")
+        out, _ = capfd.readouterr()
+        expected_output = [f.format(config="Release") for f in expected_app_outputs]
+        assert all(expected in out for expected in expected_output)
+        # the app executes its native slice, so the dispatched header must match the host
+        assert f"archconfig: {platform.machine()}" in out
+
+    def test_universal_reconfigure_uses_stamp(self, capfd):
+        "Unchanged inputs skip the installs; a conanfile content change triggers them again"
+        run(f"cmake -S {self.source_dir} -B {self.binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider} "
+            "-DCMAKE_BUILD_TYPE=Release -DCONAN_OSX_UNIVERSAL_BINARIES=ON '-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64'")
+        out, _ = capfd.readouterr()
+        assert "Universal binary build up to date" in out
+        assert "Installing configuration(s)" not in out
+        # a touch changes only the mtime, the stamp still matches
+        os.utime(self.source_dir / "conanfile.txt")
+        run(f"cmake -S {self.source_dir} -B {self.binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider} "
+            "-DCMAKE_BUILD_TYPE=Release -DCONAN_OSX_UNIVERSAL_BINARIES=ON '-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64'")
+        out, _ = capfd.readouterr()
+        assert "Universal binary build up to date" in out
+        # a content change reconfigures from the build (CMAKE_CONFIGURE_DEPENDS) and reinstalls
+        with open(self.source_dir / "conanfile.txt", "a") as f:
+            f.write("\n# force reinstall\n")
+        run("cmake --build .")
+        out, _ = capfd.readouterr()
+        assert "Universal binary build, installing each architecture separately" in out
+        assert ", 0 errors" in out
+
+    def test_universal_version_range_update(self, capfd, tmp_path, monkeypatch):
+        "A version range picking up a new package in the local cache triggers a reinstall"
+        workdir = tmp_path / "test_workdir"
+        workdir.mkdir()
+        source_dir = workdir / "src"
+        binary_dir = workdir / "build"
+        source_dir.mkdir()
+        binary_dir.mkdir()
+        (source_dir / "conanfile.txt").write_text(
+            "[requires]\nhello/[>=0.1 <1.0]\n\n[generators]\nCMakeConfigDeps\n")
+        (source_dir / "CMakeLists.txt").write_text(
+            "cmake_minimum_required(VERSION 3.24)\nproject(RangeApp CXX)\n"
+            "find_package(hello REQUIRED)\nadd_executable(app main.cpp)\n"
+            "target_link_libraries(app hello::hello)\n")
+        (source_dir / "main.cpp").write_text('#include "hello.h"\nint main(){ hello(); }\n')
+        monkeypatch.chdir(binary_dir)
+        cmd = (f"cmake -S {source_dir} -B {binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider} "
+               "-DCMAKE_BUILD_TYPE=Release -DCONAN_OSX_UNIVERSAL_BINARIES=ON "
+               "'-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64'")
+        run(cmd)
+        out, _ = capfd.readouterr()
+        assert "Universal binary build, installing each architecture separately" in out
+        # unchanged graph, the stamp hits
+        run(cmd)
+        out, _ = capfd.readouterr()
+        assert "Universal binary build up to date" in out
+        # a new version satisfying the range appears in the local cache
+        recipe_dir = tmp_path / "hello02"
+        recipe_dir.mkdir()
+        monkeypatch.chdir(recipe_dir)
+        run("conan new cmake_lib -d name=hello -d version=0.2 -f -vquiet")
+        run("conan export . -vquiet")
+        monkeypatch.chdir(binary_dir)
+        run(cmd)
+        out, err = capfd.readouterr()
+        assert "Universal binary build, installing each architecture separately" in out
+        assert "hello/0.2" in out + err
+        run("cmake --build .")
+        archs = subprocess.check_output("lipo -archs ./app", shell=True, text=True)
+        assert set(archs.split()) == {"arm64", "x86_64"}
+
+    def test_universal_space_separated_archs(self, capfd, tmp_path, monkeypatch):
+        "The space-separated CMAKE_OSX_ARCHITECTURES form (usable with the Xcode "
+        "generator, where ARCHS is space-separated) behaves like the ;-list"
+        workdir = tmp_path / "test_workdir"
+        workdir.mkdir()
+        source_dir, binary_dir = setup_cmake_workdir(workdir, resource_dirs=['macos_universal'])
+        monkeypatch.chdir(binary_dir)
+        run(f"cmake -S {source_dir} -B {binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider} "
+            "-G Xcode -DCONAN_INSTALL_BUILD_CONFIGURATIONS=Release -DCONAN_OSX_UNIVERSAL_BINARIES=ON "
+            "'-DCMAKE_OSX_ARCHITECTURES=arm64 x86_64'")
+        out, _ = capfd.readouterr()
+        assert "Universal binary build, installing each architecture separately" in out
+        assert "cmake_system_processor=armv8;x86_64" in out
+        assert ", 0 errors" in out
+
+    def test_universal_multi_config(self, capfd, tmp_path, monkeypatch):
+        "Xcode's default Release+Debug configurations install per architecture and merge cleanly"
+        workdir = tmp_path / "test_workdir"
+        workdir.mkdir()
+        source_dir, binary_dir = setup_cmake_workdir(workdir, resource_dirs=['macos_universal'])
+        monkeypatch.chdir(binary_dir)
+        run(f"cmake -S {source_dir} -B {binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider} "
+            "-G Xcode -DCONAN_OSX_UNIVERSAL_BINARIES=ON '-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64'")
+        out, _ = capfd.readouterr()
+        assert "CMake-Conan: Installing configuration(s): Release, Debug" in out
+        assert "Universal binary build, installing each architecture separately" in out
+        assert ", 0 errors" in out
+
+    def test_universal_missing_build_type(self, capfd, tmp_path, monkeypatch):
+        "A single-config generator without CMAKE_BUILD_TYPE fails before wiping anything"
+        workdir = tmp_path / "test_workdir"
+        workdir.mkdir()
+        source_dir, binary_dir = setup_cmake_workdir(workdir, resource_dirs=['macos_universal'])
+        monkeypatch.chdir(binary_dir)
+        run(f"cmake -S {source_dir} -B {binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider} "
+            "-DCONAN_OSX_UNIVERSAL_BINARIES=ON '-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64'", check=False)
+        out, err = capfd.readouterr()
+        # cmake wraps message() output at ~76 columns, compare whitespace-insensitively
+        assert "needs at least one build type" in " ".join(err.split())
+        assert "CMake-Conan: conan install" not in out
+
+    @pytest.mark.parametrize("archs,expected", [
+        ("arm64;i860", "to a Conan architecture"),
+        ("arm64;arm64e", "more than once"),
+        ("arm64;x86_64;arm64e", "at most two architectures"),
+    ])
+    def test_universal_unsupported_archs(self, capfd, tmp_path, monkeypatch, archs, expected):
+        "Unusable architecture sets fail with a clear message before any conan install"
+        workdir = tmp_path / "test_workdir"
+        workdir.mkdir()
+        source_dir, binary_dir = setup_cmake_workdir(workdir, resource_dirs=['macos_universal_archs'])
+        monkeypatch.chdir(binary_dir)
+        run(f"cmake -S {source_dir} -B {binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider} "
+            f"-DCMAKE_BUILD_TYPE=Release -DCONAN_OSX_UNIVERSAL_BINARIES=ON '-DCMAKE_OSX_ARCHITECTURES={archs}'", check=False)
+        out, err = capfd.readouterr()
+        # cmake wraps message() output at ~76 columns, compare whitespace-insensitively
+        assert expected in " ".join(err.split())
+        assert "CMake-Conan: conan install" not in out
+
+    def test_ios_multiarch_fallback(self, capfd, basic_cmake_project):
+        "Non-macOS Apple multi-arch keeps the previous single-install warning behavior"
+        source_dir, binary_dir = basic_cmake_project
+        run(f"cmake -S {source_dir} -B {binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider} "
+            "-DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphonesimulator "
+            "-DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 '-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64' "
+            "'-DCONAN_INSTALL_ARGS=--build=never'", check=False)
+        out, err = capfd.readouterr()
+        # cmake wraps message() output at ~76 columns, compare whitespace-insensitively
+        assert ("Multiple architectures detected, this will only work if "
+                "Conan recipe(s) produce fat binaries.") in " ".join(err.split())
+        assert "cmake_system_processor=armv8\n" in out
+        assert "arch=armv8" in out
+        assert "--deployer" not in out
+
+    def test_universal_disabled_by_default(self, capfd, tmp_path, monkeypatch):
+        "Without CONAN_OSX_UNIVERSAL_BINARIES the previous single-install behavior applies"
+        workdir = tmp_path / "test_workdir"
+        workdir.mkdir()
+        source_dir, binary_dir = setup_cmake_workdir(workdir, resource_dirs=['macos_universal_archs'])
+        monkeypatch.chdir(binary_dir)
+        run(f"cmake -S {source_dir} -B {binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider} "
+            "-DCMAKE_BUILD_TYPE=Release '-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64'", check=False)
+        out, err = capfd.readouterr()
+        # cmake wraps message() output at ~76 columns, compare whitespace-insensitively
+        assert ("Multiple architectures detected, this will only work if "
+                "Conan recipe(s) produce fat binaries.") in " ".join(err.split())
+        assert "Universal binary build" not in out
+        assert "--deployer" not in out
 
 
 class TestMSVCArch:


### PR DESCRIPTION
## Motivation

Universal macOS builds currently get a warning from the provider, and the build only links if every dependency happens to be universal. Conan 2.2.0's preliminary fat binaries support helps, but not every recipe supports it (OpenSSL is the usual blocker). The Conan docs themselves call one binary per architecture the more reliable path. This PR automates that path: one `conan install` per architecture merged with `lipo`.

## How it works

The PR adds one new option, `CONAN_OSX_UNIVERSAL_BINARIES`, off by default. Nothing changes unless it is enabled:

```bash
cmake -B build -S . -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=[path-to]/conan_provider.cmake \
      -DCMAKE_BUILD_TYPE=Release \
      -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
      -DCONAN_OSX_UNIVERSAL_BINARIES=ON
```

With the option on and two architectures requested, the provider does three things:

1. It runs `conan install` twice, once per architecture.
2. Each install copies its dependencies into the build directory using Conan's `full_deploy` deployer. This also makes the generated CMake files point at those copies instead of the Conan cache.
3. It merges the second architecture's copy into the first one (the primary) in place with `lipo`. After that, everything `find_package` resolves is universal.

The merge handles each file by case:

* identical on both sides (most headers, resources, prebuilt universal artifacts): shared from the primary tree as-is
* Mach-O: `lipo -create` into the primary counterpart, with the expected slices verified before and after each merge
* generated headers that legitimately differ per architecture replaced by a small `__aarch64__`/`__x86_64__` dispatcher, with both variants kept alongside
* headers or binaries that exist for only one architecture: errors

Repeated configures skip the installs and the merge while nothing relevant changed. A quick `conan lock create` probe re-resolves the dependency graph each configure, so updated pins and version ranges are picked up, and everything else (conanfile, profiles, install arguments) is hashed into a small stamp file. The probed lockfile also feeds both installs, which guarantees the two architectures resolve identical versions. Delete `<build>/conan-universal-stamp.txt` to force a rerun.

Requires Conan 2.1.0 or later. macOS targets only, and exactly the `arm64` plus `x86_64` pair. Anything else fails with a clear message.