### PR TITLE
Retry conan install offline if remote comms fails

### DIFF
--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -485,12 +485,28 @@ function(conan_install)
         endif()
     endif()
 
-    execute_process(COMMAND ${CONAN_COMMAND} install ${CMAKE_SOURCE_DIR} ${conan_args} ${ARGN} --format=json
+    foreach(attempt RANGE 1)
+        execute_process(COMMAND ${CONAN_COMMAND} install ${CMAKE_SOURCE_DIR} ${conan_args} ${ARGN} --format=json
                     RESULT_VARIABLE return_code
                     OUTPUT_VARIABLE conan_stdout
                     ERROR_VARIABLE conan_stderr
                     ECHO_ERROR_VARIABLE    # show the text output regardless
                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+        if(NOT "${return_code}" STREQUAL "0")
+            string(FIND "${conan_stderr}" "ERROR:" error_position REVERSE)
+            if (NOT error_position EQUAL -1)
+                string(SUBSTRING "${conan_stderr}" "${error_position}" -1 error_message)
+                if (error_message MATCHES [[.*ERROR: HTTPSConnectionPool.*]])
+                    message(WARNING "Conan Remote Error: '${error_message}'. Retrying with local cache only.")
+                    list(APPEND conan_args "--no-remote")
+                endif()
+            else()
+                message(FATAL_ERROR "Conan install failed='${return_code}'")
+            endif()
+        else()
+            break()
+        endif()
+    endforeach()
 
     if(DEFINED PATH_TO_CMAKE_BIN)
         set(ENV{PATH} "${old_path}")

--- a/conan_provider.cmake
+++ b/conan_provider.cmake
@@ -499,8 +499,12 @@ function(conan_install)
                 if (error_message MATCHES [[.*ERROR: HTTPSConnectionPool.*]])
                     message(WARNING "Conan Remote Error: '${error_message}'. Retrying with local cache only.")
                     list(APPEND conan_args "--no-remote")
+                else()
+                    # some other error from conan install that we don't handle
+                    message(FATAL_ERROR "Conan install failed='${return_code}'")
                 endif()
             else()
+                # some unknown error running the conan install command itself
                 message(FATAL_ERROR "Conan install failed='${return_code}'")
             endif()
         else()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -5,6 +5,7 @@ import re
 import shutil
 import subprocess
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
 
@@ -273,7 +274,19 @@ class TestBasic:
         runtime = msvc_runtime.replace("$<$<CONFIG:Debug>:Debug>", debug_tag)
         expected_runtime_outputs = [f.format(expected_runtime=runtime) for f in expected_app_msvc_runtime]
         assert all(expected in out for expected in expected_runtime_outputs)
-        
+
+    @pytest.fixture
+    def bad_remote(self):
+        run(" ".join(["conan", "remote", "add", "bad-remote", f"https://{uuid4()}"]), check=True)
+        yield
+        run(" ".join(["conan", "remote", "remove", "bad-remote"]), check=True)
+
+    def test_configure_offline(self, bad_remote):
+        generator = "-GNinja" if platform.system() == "Windows" else ""
+        run(f"cmake -S {self.source_dir} -B {self.binary_dir} -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES={conan_provider} -DCMAKE_BUILD_TYPE=Release {generator}",
+            check=True)
+
+
 class TestFindModules:
 
     @pytest.mark.parametrize("use_find_components", [True, False])


### PR DESCRIPTION
If conan install fails due to an error communicating with a remote, retry using the local cache only. (Checks for an Error from the `HttpsConnectionPool`)

I have found this workaround useful when working offline or when there are upstream issues with the remotes.